### PR TITLE
feat: local inference infrastructure (F-22, F-23, F-24)

### DIFF
--- a/adapters/__init__.py
+++ b/adapters/__init__.py
@@ -11,13 +11,16 @@ Provides a unified interface for multiple LLM providers:
 Inspired by: aionui auto-detect and fallback patterns
 """
 
-from adapters.base import LLMAdapter, LLMConfig, LLMResponse
-from adapters.router import LLMRouter, get_router
+from adapters.base import LLMAdapter, LLMConfig, LLMProvider, LLMResponse
+from adapters.router import DataClassification, LLMRouter, RoutingStrategy, get_router
 
 __all__ = [
+    "DataClassification",
     "LLMAdapter",
-    "LLMResponse",
     "LLMConfig",
+    "LLMProvider",
+    "LLMResponse",
     "LLMRouter",
+    "RoutingStrategy",
     "get_router",
 ]

--- a/adapters/base.py
+++ b/adapters/base.py
@@ -302,16 +302,19 @@ class OllamaAdapter(LLMAdapter):
         for msg in messages:
             ollama_messages.append({"role": msg.role, "content": msg.content})
 
+        options: dict[str, Any] = {
+            "temperature": temperature or self.config.temperature,
+            "num_predict": max_tokens or self.config.max_tokens,
+            "num_ctx": self.config.context_window,
+        }
+
         async with httpx.AsyncClient() as client:
             response = await client.post(
                 f"{self.base_url}/api/chat",
                 json={
                     "model": self.config.model,
                     "messages": ollama_messages,
-                    "options": {
-                        "temperature": temperature or self.config.temperature,
-                        "num_predict": max_tokens or self.config.max_tokens,
-                    },
+                    "options": options,
                     "stream": False,
                 },
                 timeout=self.config.timeout,
@@ -351,6 +354,12 @@ class OllamaAdapter(LLMAdapter):
         for msg in messages:
             ollama_messages.append({"role": msg.role, "content": msg.content})
 
+        options: dict[str, Any] = {
+            "temperature": temperature or self.config.temperature,
+            "num_predict": max_tokens or self.config.max_tokens,
+            "num_ctx": self.config.context_window,
+        }
+
         async with httpx.AsyncClient() as client:
             async with client.stream(
                 "POST",
@@ -358,10 +367,7 @@ class OllamaAdapter(LLMAdapter):
                 json={
                     "model": self.config.model,
                     "messages": ollama_messages,
-                    "options": {
-                        "temperature": temperature or self.config.temperature,
-                        "num_predict": max_tokens or self.config.max_tokens,
-                    },
+                    "options": options,
                     "stream": True,
                 },
                 timeout=self.config.timeout,

--- a/adapters/router.py
+++ b/adapters/router.py
@@ -44,6 +44,50 @@ class RoutingStrategy(StrEnum):
     SPEED_FIRST = "speed_first"  # Prefer fastest
     ROUND_ROBIN = "round_robin"  # Rotate between providers
     FALLBACK = "fallback"  # Use fallback chain
+    SENSITIVITY = "sensitivity"  # Route based on data classification
+
+
+class DataClassification(StrEnum):
+    """Data sensitivity classification for routing decisions.
+
+    Determines which providers are allowed for a given request:
+    - PUBLIC: Any provider (cloud or local)
+    - INTERNAL: Cloud or local (all providers)
+    - CONFIDENTIAL: Local only (ollama, local GGUF)
+    - REGULATED: Local only with audit logging
+    """
+
+    PUBLIC = "public"
+    INTERNAL = "internal"
+    CONFIDENTIAL = "confidential"
+    REGULATED = "regulated"
+
+
+# Which providers are allowed per classification
+CLASSIFICATION_ALLOWED_PROVIDERS: dict[DataClassification, set[LLMProvider]] = {
+    DataClassification.PUBLIC: {
+        LLMProvider.OLLAMA,
+        LLMProvider.ANTHROPIC,
+        LLMProvider.OPENAI,
+        LLMProvider.GROQ,
+        LLMProvider.LOCAL,
+    },
+    DataClassification.INTERNAL: {
+        LLMProvider.OLLAMA,
+        LLMProvider.ANTHROPIC,
+        LLMProvider.OPENAI,
+        LLMProvider.GROQ,
+        LLMProvider.LOCAL,
+    },
+    DataClassification.CONFIDENTIAL: {
+        LLMProvider.OLLAMA,
+        LLMProvider.LOCAL,
+    },
+    DataClassification.REGULATED: {
+        LLMProvider.OLLAMA,
+        LLMProvider.LOCAL,
+    },
+}
 
 
 @dataclass
@@ -285,24 +329,51 @@ class LLMRouter:
         self,
         requires_tools: bool = False,
         preferred_model: str | None = None,
+        classification: DataClassification | None = None,
     ) -> tuple[LLMProvider, bool]:
         """
         Select the best provider for a request.
+
+        Args:
+            requires_tools: Whether the request needs tool calling support
+            preferred_model: Specific model preference
+            classification: Data sensitivity classification for routing
 
         Returns:
             Tuple of (provider, supports_native_tools)
             If tools are required but no provider supports them,
             returns a provider that can simulate tools via prompts.
         """
+        # Filter providers by classification if specified
+        allowed = None
+        if classification:
+            allowed = CLASSIFICATION_ALLOWED_PROVIDERS.get(classification)
+            if allowed:
+                logger.info(
+                    "Classification=%s allows providers: %s",
+                    classification.value,
+                    [p.value for p in allowed],
+                )
+
+        chain = self._fallback_chain
+        if allowed:
+            chain = [p for p in chain if p in allowed]
+            if not chain:
+                raise LLMAdapterError(
+                    f"No available provider for classification={classification.value}. "
+                    f"Allowed: {[p.value for p in allowed]}. "
+                    f"Available: {[p.value for p in self._fallback_chain]}"
+                )
+
         # First, try to find a provider that supports tools natively
         if requires_tools:
-            for provider in self._fallback_chain:
+            for provider in chain:
                 info = self._providers[provider]
                 if info.supports_tools:
                     return provider, True
 
         # Fall back to any available provider
-        for provider in self._fallback_chain:
+        for provider in chain:
             return provider, self._providers[provider].supports_tools
 
         raise LLMAdapterError("No suitable provider available")
@@ -317,6 +388,7 @@ class LLMRouter:
         max_tokens: int | None = None,
         provider: LLMProvider | None = None,
         model: str | None = None,
+        classification: DataClassification | None = None,
     ) -> LLMResponse:
         """
         Route a completion request.
@@ -329,11 +401,21 @@ class LLMRouter:
             max_tokens: Max output tokens
             provider: Force specific provider
             model: Force specific model
+            classification: Data sensitivity classification for routing
 
         Returns:
             LLM response
         """
         await self._ensure_initialized()
+
+        # Validate explicit provider against classification
+        if provider and classification:
+            allowed = CLASSIFICATION_ALLOWED_PROVIDERS.get(classification, set())
+            if provider not in allowed:
+                raise LLMAdapterError(
+                    f"Provider {provider.value} not allowed for "
+                    f"classification={classification.value}"
+                )
 
         # Select provider
         supports_native_tools = True
@@ -342,7 +424,10 @@ class LLMRouter:
                 raise LLMAdapterError(f"Provider {provider.value} not available")
             supports_native_tools = self._providers[provider].supports_tools
         else:
-            provider, supports_native_tools = self._select_provider(requires_tools=bool(tools))
+            provider, supports_native_tools = self._select_provider(
+                requires_tools=bool(tools),
+                classification=classification,
+            )
 
         # If tools are requested but provider doesn't support them natively,
         # simulate tools via prompt injection
@@ -377,6 +462,16 @@ class LLMRouter:
                 # If using simulated tools, parse tool calls from response
                 if tools and not supports_native_tools:
                     response = self._parse_simulated_tools(response)
+
+                # Audit log for regulated data
+                if classification == DataClassification.REGULATED:
+                    logger.info(
+                        "AUDIT: regulated request completed via %s "
+                        "(model=%s, tokens=%d)",
+                        fallback_provider.value,
+                        response.model,
+                        response.total_tokens,
+                    )
 
                 return response
             except Exception as e:
@@ -467,6 +562,7 @@ If you don't need to use a tool, just respond normally.
         max_tokens: int | None = None,
         provider: LLMProvider | None = None,
         model: str | None = None,
+        classification: DataClassification | None = None,
     ) -> AsyncIterator[str]:
         """
         Route a streaming request.
@@ -479,11 +575,21 @@ If you don't need to use a tool, just respond normally.
             max_tokens: Max output tokens
             provider: Force specific provider
             model: Force specific model
+            classification: Data sensitivity classification for routing
 
         Yields:
             Response tokens
         """
         await self._ensure_initialized()
+
+        # Validate explicit provider against classification
+        if provider and classification:
+            allowed = CLASSIFICATION_ALLOWED_PROVIDERS.get(classification, set())
+            if provider not in allowed:
+                raise LLMAdapterError(
+                    f"Provider {provider.value} not allowed for "
+                    f"classification={classification.value}"
+                )
 
         supports_native_tools = True
         if provider:
@@ -491,7 +597,18 @@ If you don't need to use a tool, just respond normally.
                 raise LLMAdapterError(f"Provider {provider.value} not available")
             supports_native_tools = self._providers[provider].supports_tools
         else:
-            provider, supports_native_tools = self._select_provider(requires_tools=bool(tools))
+            provider, supports_native_tools = self._select_provider(
+                requires_tools=bool(tools),
+                classification=classification,
+            )
+
+        # Audit log for regulated streaming
+        if classification == DataClassification.REGULATED:
+            logger.info(
+                "AUDIT: regulated stream request via %s (model=%s)",
+                provider.value,
+                model or DEFAULT_MODELS.get(provider, "default"),
+            )
 
         # If tools are requested but provider doesn't support them natively,
         # simulate tools via prompt injection

--- a/docs/local-inference-setup.md
+++ b/docs/local-inference-setup.md
@@ -1,0 +1,204 @@
+# Local Inference Setup — Ollama + agentic-titan
+
+> **Features**: F-22, F-23, F-24
+> **Scope**: Local model inference for data sovereignty and cost optimization
+> **Version**: 1.0
+
+---
+
+## Prerequisites
+
+- macOS (Apple Silicon recommended) or Linux
+- Homebrew (macOS) or curl (Linux)
+- 8GB+ RAM (16GB recommended for 7B models)
+
+## Installation
+
+### macOS (Homebrew)
+
+```bash
+brew install ollama
+```
+
+### Linux
+
+```bash
+curl -fsSL https://ollama.com/install.sh | sh
+```
+
+### Verify
+
+```bash
+ollama --version
+ollama serve &   # Start the server (runs on localhost:11434)
+```
+
+## Recommended Models
+
+Models are selected for 16GB RAM constraint (Apple Silicon M3):
+
+| Model | Size | Context | Use Case |
+|-------|------|---------|----------|
+| `llama3.2:3b` | 2.0 GB | 128K | General purpose, fast |
+| `llama3.2:1b` | 1.3 GB | 128K | Lightweight tasks, embedding prep |
+| `qwen2.5:3b` | 1.9 GB | 128K | Code-aware, multilingual |
+| `gemma3:4b` | 3.3 GB | 128K | Balanced quality/speed |
+| `nomic-embed-text` | 274 MB | 8K | Embeddings only |
+
+### Pull Models
+
+```bash
+ollama pull llama3.2:3b          # Primary general model
+ollama pull nomic-embed-text     # Embeddings
+ollama pull qwen2.5:3b           # Code tasks (optional)
+```
+
+### Memory Budget
+
+With 16GB system RAM, budget ~6-8GB for models. Rules of thumb:
+- 1B model ≈ 1.3 GB VRAM
+- 3B model ≈ 2.0 GB VRAM
+- 7B model ≈ 4.5 GB VRAM (tight on 16GB with other apps)
+- Only one model loaded at a time by default
+
+## Context Window Configuration (F-23)
+
+Ollama defaults to 2K-4K context, but agents need larger windows.
+The `LLMConfig.context_window` parameter is passed as `num_ctx` to Ollama.
+
+```python
+from adapters.base import LLMConfig, LLMProvider, OllamaAdapter
+
+config = LLMConfig(
+    provider=LLMProvider.OLLAMA,
+    model="llama3.2:3b",
+    context_window=16384,  # 16K context — passed as num_ctx to Ollama
+)
+adapter = OllamaAdapter(config)
+```
+
+### Context Window Guidelines
+
+| Task Type | Recommended `context_window` |
+|-----------|------------------------------|
+| Simple Q&A | 4096 |
+| Code review | 16384 |
+| Document analysis | 32768 |
+| Multi-file agent | 65536+ |
+
+Higher context windows use more memory. On 16GB RAM with a 3B model:
+- 16K context: ~3 GB total
+- 32K context: ~4 GB total
+- 64K context: ~6 GB total
+
+## Sensitivity-Based Routing (F-24)
+
+The router enforces data classification constraints:
+
+```python
+from adapters.router import DataClassification, LLMRouter, RoutingStrategy
+
+router = LLMRouter(strategy=RoutingStrategy.SENSITIVITY)
+await router.initialize()
+
+# Public data — any provider
+response = await router.complete(
+    messages,
+    classification=DataClassification.PUBLIC,
+)
+
+# Confidential data — local only (Ollama)
+response = await router.complete(
+    messages,
+    classification=DataClassification.CONFIDENTIAL,
+)
+
+# Regulated data — local only + audit logging
+response = await router.complete(
+    messages,
+    classification=DataClassification.REGULATED,
+)
+```
+
+### Classification Tiers
+
+| Tier | Allowed Providers | Audit | Examples |
+|------|-------------------|-------|----------|
+| **PUBLIC** | All (cloud + local) | No | Public docs, open source code |
+| **INTERNAL** | All (cloud + local) | No | Internal notes, drafts |
+| **CONFIDENTIAL** | Local only (Ollama) | No | Personal data, credentials, PII |
+| **REGULATED** | Local only (Ollama) | Yes | Financial data, health data, legal |
+
+### What Happens When No Local Provider Is Available
+
+If a request is classified as CONFIDENTIAL or REGULATED but no local
+provider (Ollama) is running, the router raises `LLMAdapterError` rather
+than silently falling back to a cloud provider. This is a safety
+guarantee — confidential data never leaves the local machine.
+
+## Integration with agentic-titan
+
+### Via Router (recommended)
+
+```python
+from adapters.router import DataClassification, get_router
+
+router = get_router()
+await router.initialize()
+
+# The router auto-detects Ollama and adds it to the fallback chain
+response = await router.complete(
+    messages,
+    classification=DataClassification.CONFIDENTIAL,
+)
+```
+
+### Via Direct Adapter
+
+```python
+from adapters.base import LLMConfig, LLMProvider, OllamaAdapter, LLMMessage
+
+config = LLMConfig(
+    provider=LLMProvider.OLLAMA,
+    model="llama3.2:3b",
+    context_window=16384,
+)
+adapter = OllamaAdapter(config)
+
+response = await adapter.complete(
+    [LLMMessage(role="user", content="Analyze this code...")],
+    system="You are a code reviewer.",
+)
+```
+
+## Troubleshooting
+
+### Ollama not responding
+
+```bash
+# Check if server is running
+curl http://localhost:11434/api/tags
+
+# Restart
+killall ollama
+ollama serve &
+```
+
+### Out of memory
+
+Reduce context window or use a smaller model:
+
+```python
+config = LLMConfig(
+    provider=LLMProvider.OLLAMA,
+    model="llama3.2:1b",       # Smaller model
+    context_window=8192,        # Smaller context
+)
+```
+
+### Slow inference
+
+Apple Silicon uses GPU acceleration by default. If inference is slow:
+- Close memory-heavy apps (browsers, Docker)
+- Use a smaller model (1B vs 3B)
+- Reduce `context_window`

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -1,0 +1,247 @@
+"""Tests for LLM adapters — context window config (F-23) and sensitivity routing (F-24)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from adapters.base import LLMConfig, LLMMessage, LLMProvider, LLMResponse, OllamaAdapter
+from adapters.router import (
+    CLASSIFICATION_ALLOWED_PROVIDERS,
+    DataClassification,
+    LLMRouter,
+    RoutingStrategy,
+)
+from agents.framework.errors import LLMAdapterError
+
+# ── F-23: Context window configuration ──
+
+
+class TestContextWindowConfig:
+    """Verify num_ctx is passed to Ollama API calls."""
+
+    def test_default_context_window(self):
+        config = LLMConfig(provider=LLMProvider.OLLAMA, model="llama3.2:3b")
+        assert config.context_window == 8192
+
+    def test_custom_context_window(self):
+        config = LLMConfig(
+            provider=LLMProvider.OLLAMA,
+            model="llama3.2:3b",
+            context_window=32768,
+        )
+        assert config.context_window == 32768
+
+    @pytest.mark.asyncio
+    async def test_ollama_complete_passes_num_ctx(self):
+        config = LLMConfig(
+            provider=LLMProvider.OLLAMA,
+            model="llama3.2:3b",
+            context_window=16384,
+        )
+        adapter = OllamaAdapter(config)
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {
+            "message": {"content": "test response"},
+            "prompt_eval_count": 10,
+            "eval_count": 5,
+        }
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post = AsyncMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            messages = [LLMMessage(role="user", content="Hello")]
+            await adapter.complete(messages)
+
+            # Verify num_ctx was passed in options
+            call_args = mock_client.post.call_args
+            request_body = call_args.kwargs.get("json") or call_args[1].get("json")
+            assert request_body["options"]["num_ctx"] == 16384
+
+    @pytest.mark.asyncio
+    async def test_ollama_stream_passes_num_ctx(self):
+        config = LLMConfig(
+            provider=LLMProvider.OLLAMA,
+            model="llama3.2:3b",
+            context_window=32768,
+        )
+        adapter = OllamaAdapter(config)
+
+        mock_response = AsyncMock()
+        mock_response.aiter_lines = AsyncMock(return_value=AsyncMock())
+
+        async def mock_lines():
+            yield '{"message": {"content": "hi"}, "done": false}'
+            yield '{"message": {"content": ""}, "done": true}'
+
+        mock_response.aiter_lines = mock_lines
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_stream_ctx = AsyncMock()
+            mock_stream_ctx.__aenter__ = AsyncMock(return_value=mock_response)
+            mock_stream_ctx.__aexit__ = AsyncMock(return_value=False)
+            mock_client.stream = MagicMock(return_value=mock_stream_ctx)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            messages = [LLMMessage(role="user", content="Hello")]
+            tokens = []
+            async for token in adapter.stream(messages):
+                tokens.append(token)
+
+            # Verify num_ctx was passed in options
+            call_args = mock_client.stream.call_args
+            request_body = call_args.kwargs.get("json") or call_args[1]["json"]
+            assert request_body["options"]["num_ctx"] == 32768
+
+
+# ── F-24: Sensitivity-based model routing ──
+
+
+class TestDataClassification:
+    """Verify data classification enum and allowed providers."""
+
+    def test_classification_values(self):
+        assert DataClassification.PUBLIC == "public"
+        assert DataClassification.INTERNAL == "internal"
+        assert DataClassification.CONFIDENTIAL == "confidential"
+        assert DataClassification.REGULATED == "regulated"
+
+    def test_public_allows_all_providers(self):
+        allowed = CLASSIFICATION_ALLOWED_PROVIDERS[DataClassification.PUBLIC]
+        assert LLMProvider.ANTHROPIC in allowed
+        assert LLMProvider.OPENAI in allowed
+        assert LLMProvider.OLLAMA in allowed
+        assert LLMProvider.GROQ in allowed
+
+    def test_confidential_allows_only_local(self):
+        allowed = CLASSIFICATION_ALLOWED_PROVIDERS[DataClassification.CONFIDENTIAL]
+        assert LLMProvider.OLLAMA in allowed
+        assert LLMProvider.LOCAL in allowed
+        assert LLMProvider.ANTHROPIC not in allowed
+        assert LLMProvider.OPENAI not in allowed
+        assert LLMProvider.GROQ not in allowed
+
+    def test_regulated_allows_only_local(self):
+        allowed = CLASSIFICATION_ALLOWED_PROVIDERS[DataClassification.REGULATED]
+        assert LLMProvider.OLLAMA in allowed
+        assert LLMProvider.LOCAL in allowed
+        assert LLMProvider.ANTHROPIC not in allowed
+
+
+class TestSensitivityRouting:
+    """Verify router enforces classification constraints."""
+
+    @pytest.mark.asyncio
+    async def test_confidential_blocks_cloud_provider(self):
+        router = LLMRouter(strategy=RoutingStrategy.FALLBACK)
+        # Manually set up providers
+        router._initialized = True
+        router._providers = {
+            LLMProvider.ANTHROPIC: MagicMock(available=True, supports_tools=True),
+            LLMProvider.OPENAI: MagicMock(available=True, supports_tools=True),
+        }
+        router._fallback_chain = [LLMProvider.ANTHROPIC, LLMProvider.OPENAI]
+
+        # Should raise because no local provider is available
+        with pytest.raises(LLMAdapterError, match="No available provider"):
+            router._select_provider(classification=DataClassification.CONFIDENTIAL)
+
+    @pytest.mark.asyncio
+    async def test_confidential_allows_ollama(self):
+        router = LLMRouter(strategy=RoutingStrategy.FALLBACK)
+        router._initialized = True
+        router._providers = {
+            LLMProvider.ANTHROPIC: MagicMock(
+                available=True, supports_tools=True, cost_tier=3
+            ),
+            LLMProvider.OLLAMA: MagicMock(
+                available=True, supports_tools=False, cost_tier=1
+            ),
+        }
+        router._fallback_chain = [LLMProvider.ANTHROPIC, LLMProvider.OLLAMA]
+
+        provider, _ = router._select_provider(
+            classification=DataClassification.CONFIDENTIAL,
+        )
+        assert provider == LLMProvider.OLLAMA
+
+    @pytest.mark.asyncio
+    async def test_public_allows_any_provider(self):
+        router = LLMRouter(strategy=RoutingStrategy.FALLBACK)
+        router._initialized = True
+        router._providers = {
+            LLMProvider.ANTHROPIC: MagicMock(
+                available=True, supports_tools=True, cost_tier=3
+            ),
+            LLMProvider.OLLAMA: MagicMock(
+                available=True, supports_tools=False, cost_tier=1
+            ),
+        }
+        router._fallback_chain = [LLMProvider.ANTHROPIC, LLMProvider.OLLAMA]
+
+        provider, _ = router._select_provider(
+            classification=DataClassification.PUBLIC,
+        )
+        # Should pick first in chain (Anthropic)
+        assert provider == LLMProvider.ANTHROPIC
+
+    @pytest.mark.asyncio
+    async def test_explicit_provider_blocked_by_classification(self):
+        router = LLMRouter(strategy=RoutingStrategy.FALLBACK)
+        router._initialized = True
+        router._providers = {
+            LLMProvider.ANTHROPIC: MagicMock(available=True, supports_tools=True),
+        }
+        router._fallback_chain = [LLMProvider.ANTHROPIC]
+
+        with pytest.raises(LLMAdapterError, match="not allowed"):
+            await router.complete(
+                [LLMMessage(role="user", content="secret data")],
+                provider=LLMProvider.ANTHROPIC,
+                classification=DataClassification.CONFIDENTIAL,
+            )
+
+    @pytest.mark.asyncio
+    async def test_regulated_logs_audit(self, caplog):
+        """Verify AUDIT log entry for regulated requests."""
+        router = LLMRouter(strategy=RoutingStrategy.FALLBACK)
+        router._initialized = True
+
+        mock_adapter = AsyncMock()
+        mock_adapter.complete = AsyncMock(
+            return_value=LLMResponse(
+                content="ok",
+                model="llama3.2:3b",
+                provider="ollama",
+                usage={"total_tokens": 42},
+            )
+        )
+
+        router._providers = {
+            LLMProvider.OLLAMA: MagicMock(
+                available=True, supports_tools=False, cost_tier=1
+            ),
+        }
+        router._fallback_chain = [LLMProvider.OLLAMA]
+        router._adapters = {LLMProvider.OLLAMA: mock_adapter}
+
+        import logging
+
+        with caplog.at_level(logging.INFO, logger="titan.adapters.router"):
+            await router.complete(
+                [LLMMessage(role="user", content="regulated data")],
+                classification=DataClassification.REGULATED,
+            )
+
+        assert any("AUDIT" in record.message for record in caplog.records)


### PR DESCRIPTION
## Summary

- **F-22**: Ollama setup documentation — model recommendations for 16GB RAM, integration patterns
- **F-23**: Context window config — `num_ctx` passed to Ollama API in both `complete()` and `stream()`
- **F-24**: Sensitivity-based routing — 4-tier data classification (PUBLIC/INTERNAL/CONFIDENTIAL/REGULATED), local-only enforcement for sensitive data, AUDIT logging for regulated requests

Fixes #12, Fixes #13, Fixes #14

## Test plan

- [x] 13 new tests pass (`tests/test_adapters.py`)
- [x] `ruff check` clean
- [ ] `ollama run llama3.2:3b` works locally (verified: ollama v0.17.7 with 5 models)
- [ ] Verify context window with `num_ctx=16384` produces longer responses than default

🤖 Generated with [Claude Code](https://claude.com/claude-code)