### PR TITLE
fix: SWARM density=1.0 saturates criticality model (#67)

### DIFF
--- a/hive/criticality.py
+++ b/hive/criticality.py
@@ -415,7 +415,10 @@ class CriticalityMonitor:
         # metrics are trivially maximal and cannot detect phase transitions.
         # Use topological neighbor ratio as effective density instead.
         if density > 0.95 and total_agents > 2:
-            neighbor_count = int(stats.get("neighbor_count", total_agents - 1))
+            neighbor_count = min(
+                int(stats.get("neighbor_count", total_agents - 1)),
+                total_agents - 1,  # Clamp k to feasible neighbors in small swarms
+            )
             effective_density = neighbor_count / (total_agents - 1)
             order = effective_density * 0.5 + avg_clustering * 0.5
         else:

--- a/hive/criticality.py
+++ b/hive/criticality.py
@@ -394,6 +394,11 @@ class CriticalityMonitor:
 
         Order parameter ~ 1: highly organized
         Order parameter ~ 0: disordered
+
+        When structural density is saturated (≈1.0, e.g. SWARM topology),
+        uses topological neighbor ratio (k/N) as effective density instead
+        of raw structural density. This follows Cavagna et al. 2010:
+        functional interactions are topological, not metric.
         """
         if not self._neighborhood:
             return 0.5  # Default balanced
@@ -406,9 +411,15 @@ class CriticalityMonitor:
         if total_agents < 2:
             return 0.5
 
-        # Order parameter based on network organization
-        # High density + high clustering = high order
-        order = density * 0.5 + avg_clustering * 0.5
+        # When density is saturated (all-to-all, e.g. SWARM), structural
+        # metrics are trivially maximal and cannot detect phase transitions.
+        # Use topological neighbor ratio as effective density instead.
+        if density > 0.95 and total_agents > 2:
+            neighbor_count = int(stats.get("neighbor_count", total_agents - 1))
+            effective_density = neighbor_count / (total_agents - 1)
+            order = effective_density * 0.5 + avg_clustering * 0.5
+        else:
+            order = density * 0.5 + avg_clustering * 0.5
 
         # Record for tracking
         self._state_samples.append(order)

--- a/tests/test_hive/test_criticality.py
+++ b/tests/test_hive/test_criticality.py
@@ -380,3 +380,22 @@ class TestSwarmDensitySaturation:
         order_k15 = await monitor_k15._measure_order_parameter()
 
         assert order_k3 < order_k15, "Higher k should produce higher order parameter"
+
+    @pytest.mark.asyncio
+    async def test_small_swarm_clamps_k(self):
+        """In small swarms where k > N-1, effective_density stays <= 1.0."""
+        neighborhood = MagicMock()
+        neighborhood.get_network_stats.return_value = {
+            "total_agents": 4,
+            "average_clustering": 1.0,
+            "density": 1.0,
+            "neighbor_count": 7,  # k=7 > N-1=3
+        }
+        neighborhood._profiles = {}
+
+        monitor = CriticalityMonitor(neighborhood=neighborhood)
+        order = await monitor._measure_order_parameter()
+
+        # k clamped to 3, effective_density = 3/3 = 1.0
+        # order = 1.0*0.5 + 1.0*0.5 = 1.0 (but never > 1.0)
+        assert order <= 1.0

--- a/tests/test_hive/test_criticality.py
+++ b/tests/test_hive/test_criticality.py
@@ -291,3 +291,92 @@ class TestCriticalityMonitor:
 
         # Should have some metrics history
         assert len(monitor._metrics_history) >= 1
+
+
+class TestSwarmDensitySaturation:
+    """Tests for SWARM topology density saturation fix (#67)."""
+
+    @pytest.fixture
+    def swarm_neighborhood(self):
+        """Mock neighborhood with SWARM-like saturated density."""
+        neighborhood = MagicMock()
+        neighborhood.get_network_stats.return_value = {
+            "total_agents": 20,
+            "average_clustering": 1.0,
+            "density": 1.0,  # SWARM: all-to-all
+            "neighbor_count": 7,  # Topological k=7
+        }
+        neighborhood._profiles = {}
+        return neighborhood
+
+    @pytest.fixture
+    def normal_neighborhood(self):
+        """Mock neighborhood with normal (non-saturated) density."""
+        neighborhood = MagicMock()
+        neighborhood.get_network_stats.return_value = {
+            "total_agents": 20,
+            "average_clustering": 0.5,
+            "density": 0.4,
+            "neighbor_count": 7,
+        }
+        neighborhood._profiles = {}
+        return neighborhood
+
+    @pytest.mark.asyncio
+    async def test_swarm_order_parameter_not_saturated(self, swarm_neighborhood):
+        """SWARM density=1.0 should NOT produce order_parameter=1.0."""
+        monitor = CriticalityMonitor(neighborhood=swarm_neighborhood)
+        order = await monitor._measure_order_parameter()
+
+        # With k=7, N=20: effective_density = 7/19 ≈ 0.368
+        # order = 0.368*0.5 + 1.0*0.5 = 0.684 (not 1.0)
+        assert order < 0.9, f"Order parameter {order} still saturated for SWARM"
+
+    @pytest.mark.asyncio
+    async def test_swarm_can_be_supercritical(self, swarm_neighborhood):
+        """SWARM should be able to reach SUPERCRITICAL state."""
+        monitor = CriticalityMonitor(neighborhood=swarm_neighborhood)
+        order = await monitor._measure_order_parameter()
+
+        # order_parameter < 0.8 means SUBCRITICAL gate does NOT fire
+        assert order < 0.8, "SWARM should not be trapped in SUBCRITICAL"
+
+    @pytest.mark.asyncio
+    async def test_normal_density_unchanged(self, normal_neighborhood):
+        """Non-saturated density calculation is unchanged."""
+        monitor = CriticalityMonitor(neighborhood=normal_neighborhood)
+        order = await monitor._measure_order_parameter()
+
+        # Normal: density=0.4, clustering=0.5
+        # order = 0.4*0.5 + 0.5*0.5 = 0.45
+        expected = 0.4 * 0.5 + 0.5 * 0.5
+        assert abs(order - expected) < 0.01
+
+    @pytest.mark.asyncio
+    async def test_swarm_effective_density_scales_with_k(self):
+        """Effective density scales with topological neighbor count."""
+        neighborhood_k3 = MagicMock()
+        neighborhood_k3.get_network_stats.return_value = {
+            "total_agents": 20,
+            "average_clustering": 1.0,
+            "density": 1.0,
+            "neighbor_count": 3,
+        }
+        neighborhood_k3._profiles = {}
+
+        neighborhood_k15 = MagicMock()
+        neighborhood_k15.get_network_stats.return_value = {
+            "total_agents": 20,
+            "average_clustering": 1.0,
+            "density": 1.0,
+            "neighbor_count": 15,
+        }
+        neighborhood_k15._profiles = {}
+
+        monitor_k3 = CriticalityMonitor(neighborhood=neighborhood_k3)
+        monitor_k15 = CriticalityMonitor(neighborhood=neighborhood_k15)
+
+        order_k3 = await monitor_k3._measure_order_parameter()
+        order_k15 = await monitor_k15._measure_order_parameter()
+
+        assert order_k3 < order_k15, "Higher k should produce higher order parameter"


### PR DESCRIPTION
## Summary
- SWARM topology's all-to-all connectivity (density=1.0) produced order_parameter=1.0, trapping the system in SUBCRITICAL state
- When density > 0.95, now uses topological neighbor ratio (k/N-1) as effective density instead of raw structural density
- Follows Cavagna et al. 2010: functional interactions in starling flocks are topological (k nearest), not metric (all within radius)
- Non-saturated topologies are completely unaffected

Closes #67

## Test plan
- [x] 4 new tests in `TestSwarmDensitySaturation`
- [x] SWARM order parameter drops from 1.0 to ~0.68 (k=7, N=20)
- [x] Normal density calculation unchanged
- [x] Effective density scales with k
- [x] Full hive suite: 153/153 passing
- [x] `ruff check` + `mypy` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)