### PR TITLE
feat: post-transition cooldown for FissionFusionManager (#68)

### DIFF
--- a/hive/fission_fusion.py
+++ b/hive/fission_fusion.py
@@ -221,6 +221,10 @@ class FissionFusionManager:
         self._eval_task: asyncio.Task[None] | None = None
         self._running = False
 
+        # Post-transition cooldown (refractory period)
+        self._last_transition_time: datetime | None = None
+        self._cooldown_seconds = evaluation_interval * 2  # Default: 2× eval interval
+
         # Manual crisis override (set via set_crisis_level)
         self._manual_crisis_level: float | None = None
 
@@ -396,6 +400,12 @@ class FissionFusionManager:
         Returns:
             Target state, or None if no transition needed.
         """
+        # Cooldown gate: suppress transitions during refractory period
+        if self._last_transition_time is not None:
+            elapsed = (datetime.now(UTC) - self._last_transition_time).total_seconds()
+            if elapsed < self._cooldown_seconds:
+                return None
+
         if self._state == FissionFusionState.TRANSITIONING:
             # Complete current transition
             return self._metrics.suggest_state()
@@ -432,11 +442,13 @@ class FissionFusionManager:
         # Get all agents
         if not self._neighborhood:
             self._state = FissionFusionState.FISSION
+            self._last_transition_time = datetime.now(UTC)
             return 0
 
         agents = list(self._neighborhood._profiles.keys())
         if not agents:
             self._state = FissionFusionState.FISSION
+            self._last_transition_time = datetime.now(UTC)
             return 0
 
         # Cluster based on task similarity
@@ -479,6 +491,7 @@ class FissionFusionManager:
         metrics.set_cluster_count(clusters_formed)
         metrics.set_fission_fusion_state(FissionFusionState.FISSION.value)
 
+        self._last_transition_time = datetime.now(UTC)
         logger.info(f"Fission completed: {clusters_formed} clusters formed")
 
         # Notify callbacks
@@ -612,6 +625,7 @@ class FissionFusionManager:
         metrics.set_cluster_count(0)
         metrics.set_fission_fusion_state(FissionFusionState.FUSION.value)
 
+        self._last_transition_time = datetime.now(UTC)
         logger.info(f"Fusion completed: info center {self._info_center_id}")
 
         # Notify callbacks

--- a/tests/test_hive/test_fission_fusion.py
+++ b/tests/test_hive/test_fission_fusion.py
@@ -337,6 +337,7 @@ class TestFissionFusionManager:
         assert manager._running is False
 
 
+
 class TestCrisisLevelResolution:
     """Tests for crisis_level signal resolution (#70)."""
 
@@ -442,3 +443,64 @@ class TestCrisisLevelResolution:
         manager.clear_crisis_override()
         crisis = manager._resolve_crisis_level()
         assert crisis > 0.5  # Back to supercritical-derived
+
+
+class TestTransitionCooldown:
+    """Tests for post-transition cooldown / refractory period (#68)."""
+
+    @pytest.mark.asyncio
+    async def test_cooldown_blocks_immediate_transition(self):
+        """Transition is suppressed during cooldown period."""
+        manager = FissionFusionManager(evaluation_interval=30.0)
+
+        # Perform fission (sets _last_transition_time)
+        await manager.perform_fission()
+
+        # Now set metrics that would normally trigger fusion
+        manager._metrics.task_correlation = 0.9
+        manager._metrics.crisis_level = 0.8
+
+        # Transition should be blocked by cooldown
+        result = await manager.should_transition()
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_no_cooldown_initially(self):
+        """No cooldown before any transition has occurred."""
+        manager = FissionFusionManager()
+        assert manager._last_transition_time is None
+
+        # Set metrics that trigger fusion
+        manager._metrics.task_correlation = 0.9
+        result = await manager.should_transition()
+        assert result == FissionFusionState.FUSION
+
+    @pytest.mark.asyncio
+    async def test_cooldown_default_is_2x_interval(self):
+        """Default cooldown is 2× evaluation_interval."""
+        manager = FissionFusionManager(evaluation_interval=15.0)
+        assert manager._cooldown_seconds == 30.0
+
+    @pytest.mark.asyncio
+    async def test_fusion_also_sets_cooldown(self):
+        """perform_fusion also records transition time."""
+        manager = FissionFusionManager()
+        await manager.perform_fusion()
+        assert manager._last_transition_time is not None
+
+    @pytest.mark.asyncio
+    async def test_cooldown_expires(self):
+        """After cooldown expires, transitions are allowed again."""
+        from datetime import timedelta
+
+        manager = FissionFusionManager(evaluation_interval=1.0)  # 2s cooldown
+
+        await manager.perform_fission()
+
+        # Backdate the transition time to simulate cooldown expiry
+        manager._last_transition_time = manager._last_transition_time - timedelta(seconds=5)
+
+        # Set metrics that trigger fusion
+        manager._metrics.task_correlation = 0.9
+        result = await manager.should_transition()
+        assert result == FissionFusionState.FUSION


### PR DESCRIPTION
## Summary
- Add refractory period after fission/fusion transitions to prevent rapid oscillation
- Default cooldown: `2 × evaluation_interval` (60s at default 30s interval)
- `should_transition()` returns `None` during cooldown — hysteresis alone was insufficient for conflict-resolution transitions
- Both `perform_fission()` and `perform_fusion()` record transition time (including early-return paths)

Closes #68

## Test plan
- [x] 5 new tests in `TestTransitionCooldown`
- [x] Cooldown blocks immediate re-transition
- [x] No cooldown before first transition
- [x] Cooldown expires after configured duration
- [x] Full fission-fusion suite: 34/34 passing
- [x] `ruff check` + `mypy` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)