### PR TITLE
feat: add functional_connectivity to CriticalityMetrics (#66)

### DIFF
--- a/hive/criticality.py
+++ b/hive/criticality.py
@@ -61,6 +61,7 @@ class CriticalityMetrics:
     relaxation_time: float = 0.0  # Seconds to equilibrium
     fluctuation_size: float = 0.0  # Variance in order parameter
     order_parameter: float = 0.5  # Measure of system organization (0-1)
+    functional_connectivity: float = 0.5  # Ratio of meaningful to total interactions (0-1)
     timestamp: datetime = field(default_factory=lambda: datetime.now(UTC))
 
     @property
@@ -310,7 +311,8 @@ class CriticalityMonitor:
         susceptibility = await self._measure_susceptibility()
         relaxation_time = await self._measure_relaxation_time()
         fluctuation_size = await self._measure_fluctuation_size()
-        order_parameter = await self._measure_order_parameter()
+        functional_connectivity = await self._measure_functional_connectivity()
+        order_parameter = await self._measure_order_parameter(functional_connectivity)
 
         return CriticalityMetrics(
             correlation_length=correlation_length,
@@ -318,6 +320,7 @@ class CriticalityMonitor:
             relaxation_time=relaxation_time,
             fluctuation_size=fluctuation_size,
             order_parameter=order_parameter,
+            functional_connectivity=functional_connectivity,
         )
 
     async def _measure_correlation_length(self) -> float:
@@ -389,7 +392,36 @@ class CriticalityMonitor:
 
         return min(1.0, statistics.stdev(samples))
 
-    async def _measure_order_parameter(self) -> float:
+    async def _measure_functional_connectivity(self) -> float:
+        """Measure ratio of meaningful interactions to total interactions.
+
+        Functional connectivity separates semantic throughput from structural
+        connectivity. A fully-connected graph (SWARM) can have low functional
+        connectivity if agents cannot comprehend each other's outputs.
+
+        Uses interaction count vs. edge count from the neighborhood network.
+        """
+        if not self._neighborhood:
+            return 0.5  # Default moderate
+
+        stats = self._neighborhood.get_network_stats()
+        total_agents = int(stats.get("total_agents", 0))
+        total_interactions = int(stats.get("total_interactions", 0))
+        total_edges = int(stats.get("total_edges", 0))
+
+        if total_edges == 0 or total_agents < 2:
+            return 0.5
+
+        # Ratio of actual interactions to possible edges
+        # High ratio = agents are meaningfully using their connections
+        # Low ratio = structural connections exist but aren't producing dialogue
+        interaction_ratio = min(1.0, total_interactions / max(1, total_edges))
+
+        return interaction_ratio
+
+    async def _measure_order_parameter(
+        self, functional_connectivity: float | None = None,
+    ) -> float:
         """Measure degree of system organization.
 
         Order parameter ~ 1: highly organized
@@ -411,18 +443,23 @@ class CriticalityMonitor:
         if total_agents < 2:
             return 0.5
 
-        # When density is saturated (all-to-all, e.g. SWARM), structural
-        # metrics are trivially maximal and cannot detect phase transitions.
-        # Use topological neighbor ratio as effective density instead.
+        # Structural order: density + clustering (who CAN talk)
+        # When density is saturated (all-to-all, e.g. SWARM), use topological
+        # neighbor ratio as effective density (Cavagna et al. 2010).
         if density > 0.95 and total_agents > 2:
             neighbor_count = min(
                 int(stats.get("neighbor_count", total_agents - 1)),
                 total_agents - 1,  # Clamp k to feasible neighbors in small swarms
             )
             effective_density = neighbor_count / (total_agents - 1)
-            order = effective_density * 0.5 + avg_clustering * 0.5
+            structural_order = effective_density * 0.5 + avg_clustering * 0.5
         else:
-            order = density * 0.5 + avg_clustering * 0.5
+            structural_order = density * 0.5 + avg_clustering * 0.5
+
+        # Blend structural and functional connectivity
+        # Functional connectivity captures who IS meaningfully communicating
+        func_conn = functional_connectivity if functional_connectivity is not None else 0.5
+        order = structural_order * 0.6 + func_conn * 0.4
 
         # Record for tracking
         self._state_samples.append(order)
@@ -546,6 +583,7 @@ class CriticalityMonitor:
                 "relaxation_time": self._current_metrics.relaxation_time,
                 "fluctuation_size": self._current_metrics.fluctuation_size,
                 "order_parameter": self._current_metrics.order_parameter,
+                "functional_connectivity": self._current_metrics.functional_connectivity,
                 "criticality_score": self._current_metrics.criticality_score,
             },
             "transitions_count": len(self._transitions),

--- a/tests/test_hive/test_criticality.py
+++ b/tests/test_hive/test_criticality.py
@@ -149,6 +149,8 @@ class TestCriticalityMonitor:
             "total_agents": 10,
             "average_clustering": 0.5,
             "density": 0.4,
+            "total_edges": 36,
+            "total_interactions": 18,
         }
         neighborhood._profiles = {}
         return neighborhood
@@ -343,13 +345,14 @@ class TestSwarmDensitySaturation:
 
     @pytest.mark.asyncio
     async def test_normal_density_unchanged(self, normal_neighborhood):
-        """Non-saturated density calculation is unchanged."""
+        """Non-saturated density structural calculation is unchanged."""
         monitor = CriticalityMonitor(neighborhood=normal_neighborhood)
-        order = await monitor._measure_order_parameter()
+        # Pass functional_connectivity=0.5 (default) to isolate structural behavior
+        order = await monitor._measure_order_parameter(functional_connectivity=0.5)
 
-        # Normal: density=0.4, clustering=0.5
-        # order = 0.4*0.5 + 0.5*0.5 = 0.45
-        expected = 0.4 * 0.5 + 0.5 * 0.5
+        # structural_order = 0.4*0.5 + 0.5*0.5 = 0.45
+        # order = 0.45*0.6 + 0.5*0.4 = 0.47
+        expected = (0.4 * 0.5 + 0.5 * 0.5) * 0.6 + 0.5 * 0.4
         assert abs(order - expected) < 0.01
 
     @pytest.mark.asyncio
@@ -399,3 +402,124 @@ class TestSwarmDensitySaturation:
         # k clamped to 3, effective_density = 3/3 = 1.0
         # order = 1.0*0.5 + 1.0*0.5 = 1.0 (but never > 1.0)
         assert order <= 1.0
+
+
+class TestFunctionalConnectivity:
+    """Tests for functional_connectivity metric (#66)."""
+
+    def test_field_exists_with_default(self):
+        """CriticalityMetrics has functional_connectivity with sensible default."""
+        m = CriticalityMetrics()
+        assert m.functional_connectivity == 0.5
+
+    def test_field_in_constructor(self):
+        """functional_connectivity can be set at construction."""
+        m = CriticalityMetrics(functional_connectivity=0.8)
+        assert m.functional_connectivity == 0.8
+
+    @pytest.mark.asyncio
+    async def test_measurement_with_interactions(self):
+        """Functional connectivity = interactions / edges."""
+        neighborhood = MagicMock()
+        neighborhood.get_network_stats.return_value = {
+            "total_agents": 10,
+            "total_edges": 40,
+            "total_interactions": 20,
+            "average_clustering": 0.5,
+            "density": 0.4,
+        }
+        neighborhood._profiles = {}
+
+        monitor = CriticalityMonitor(neighborhood=neighborhood)
+        fc = await monitor._measure_functional_connectivity()
+
+        assert fc == 0.5  # 20/40
+
+    @pytest.mark.asyncio
+    async def test_measurement_no_edges(self):
+        """Returns default when no edges exist."""
+        neighborhood = MagicMock()
+        neighborhood.get_network_stats.return_value = {
+            "total_agents": 1,
+            "total_edges": 0,
+            "total_interactions": 0,
+            "average_clustering": 0.0,
+            "density": 0.0,
+        }
+        neighborhood._profiles = {}
+
+        monitor = CriticalityMonitor(neighborhood=neighborhood)
+        fc = await monitor._measure_functional_connectivity()
+
+        assert fc == 0.5
+
+    @pytest.mark.asyncio
+    async def test_measurement_no_neighborhood(self):
+        """Returns default when no neighborhood available."""
+        monitor = CriticalityMonitor()
+        fc = await monitor._measure_functional_connectivity()
+
+        assert fc == 0.5
+
+    @pytest.mark.asyncio
+    async def test_measurement_capped_at_1(self):
+        """Functional connectivity never exceeds 1.0."""
+        neighborhood = MagicMock()
+        neighborhood.get_network_stats.return_value = {
+            "total_agents": 5,
+            "total_edges": 10,
+            "total_interactions": 50,  # More interactions than edges
+            "average_clustering": 0.5,
+            "density": 0.5,
+        }
+        neighborhood._profiles = {}
+
+        monitor = CriticalityMonitor(neighborhood=neighborhood)
+        fc = await monitor._measure_functional_connectivity()
+
+        assert fc == 1.0
+
+    @pytest.mark.asyncio
+    async def test_included_in_sample_state(self):
+        """sample_state() populates functional_connectivity."""
+        neighborhood = MagicMock()
+        neighborhood.get_network_stats.return_value = {
+            "total_agents": 10,
+            "total_edges": 40,
+            "total_interactions": 30,
+            "average_clustering": 0.5,
+            "density": 0.4,
+        }
+        neighborhood._profiles = {}
+
+        monitor = CriticalityMonitor(neighborhood=neighborhood)
+        metrics = await monitor.sample_state()
+
+        assert metrics.functional_connectivity == 0.75  # 30/40
+
+    @pytest.mark.asyncio
+    async def test_order_parameter_blends_functional(self):
+        """Order parameter includes functional_connectivity in calculation."""
+        neighborhood = MagicMock()
+        neighborhood.get_network_stats.return_value = {
+            "total_agents": 10,
+            "total_edges": 36,
+            "total_interactions": 0,  # No meaningful interactions
+            "average_clustering": 0.5,
+            "density": 0.4,
+        }
+        neighborhood._profiles = {}
+
+        monitor = CriticalityMonitor(neighborhood=neighborhood)
+        # Pass zero functional_connectivity explicitly
+        order = await monitor._measure_order_parameter(functional_connectivity=0.0)
+
+        # structural_order = 0.4*0.5 + 0.5*0.5 = 0.45
+        # order = 0.45*0.6 + 0.0*0.4 = 0.27
+        assert order < 0.3  # Pulled down by zero functional connectivity
+
+    def test_serialization_includes_functional(self):
+        """to_dict includes functional_connectivity."""
+        monitor = CriticalityMonitor()
+        data = monitor.to_dict()
+        assert "functional_connectivity" in data["current_metrics"]


### PR DESCRIPTION
## Summary
- Add `functional_connectivity: float` field to `CriticalityMetrics` — ratio of meaningful interactions to total edges
- `_measure_functional_connectivity()` samples interaction/edge ratio from neighborhood stats
- Order parameter now blends 60% structural (density+clustering) + 40% functional connectivity
- Structural/functional separation enables detecting "connected but incomprehensible" states (SWARM where agents can't decode each other)
- `_measure_order_parameter()` takes explicit functional_connectivity parameter to avoid reading stale cached metrics

Closes #66

## Test plan
- [x] 9 new tests in `TestFunctionalConnectivity`
- [x] Field defaults, construction, measurement, capping, serialization
- [x] Full hive suite: 185/185 passing
- [x] `ruff check` + `mypy` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)