### PR TITLE
Address technical debt and topology gating

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,34 @@
+# EditorConfig — https://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[*.{py,pyi}]
+indent_size = 4
+
+[*.{go}]
+indent_style = tab
+
+[*.{rs}]
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab
+
+[*.{sh,bash,zsh}]
+indent_size = 2
+
+[*.{yaml,yml}]
+indent_size = 2
+
+[*.{toml}]
+indent_size = 2

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,71 @@
+# Auto-detect text files and normalize line endings
+* text=auto
+
+# Source code
+*.py text diff=python
+*.ts text diff=typescript
+*.tsx text diff=typescript
+*.js text diff=javascript
+*.jsx text diff=javascript
+*.go text diff=go
+*.rs text diff=rust
+*.rb text diff=ruby
+*.sh text eol=lf diff=bash
+*.bash text eol=lf diff=bash
+*.zsh text eol=lf diff=bash
+*.lua text
+
+# Configuration
+*.json text
+*.yaml text
+*.yml text
+*.toml text
+*.cfg text
+*.ini text
+*.conf text
+*.env text
+
+# Templates
+*.tmpl text
+*.j2 text
+
+# Documentation
+*.md text diff=markdown
+*.txt text
+*.rst text
+
+# Web
+*.html text diff=html
+*.css text diff=css
+*.scss text diff=css
+*.astro text
+*.svg text
+
+# Build / lock files
+package-lock.json text -diff
+yarn.lock text -diff
+Cargo.lock text -diff
+poetry.lock text -diff
+
+# Binary
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.webp binary
+*.woff binary
+*.woff2 binary
+*.ttf binary
+*.eot binary
+*.pdf binary
+*.zip binary
+*.gz binary
+*.tar binary
+*.db binary
+*.sqlite binary
+
+# Force LF for scripts
+Makefile text eol=lf
+Dockerfile text eol=lf
+justfile text eol=lf

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -19,7 +19,7 @@ jobs:
         run: |
           FOUND=0
           for pattern in 'sk-[a-zA-Z0-9]{20,}' 'ghp_[a-zA-Z0-9]{36}' 'AKIA[A-Z0-9]{16}' 'sk-ant-[a-zA-Z0-9]{20,}'; do
-            if git grep -lP "$pattern" -- ':!.github' ':!node_modules' ':!.venv' 2>/dev/null; then
+            if git grep -lP "$pattern" -- ':!.github' ':!node_modules' ':!.venv' ':!tests' ':!.ci' 2>/dev/null; then
               echo "::error::Potential secret pattern found: $pattern"
               FOUND=1
             fi

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -19,9 +19,22 @@ jobs:
         run: |
           FOUND=0
           for pattern in 'sk-[a-zA-Z0-9]{20,}' 'ghp_[a-zA-Z0-9]{36}' 'AKIA[A-Z0-9]{16}' 'sk-ant-[a-zA-Z0-9]{20,}'; do
-            if git grep -lP "$pattern" -- ':!.github' ':!node_modules' ':!.venv' 2>/dev/null; then
-              echo "::error::Potential secret pattern found: $pattern"
+            PATTERN_FOUND=0
+            while IFS=: read -r file line content; do
+              case "$file" in
+                .ci/*|.github/*|node_modules/*|.venv/*)
+                  continue
+                  ;;
+              esac
+              if [[ "$content" == *"allow-secret"* ]]; then
+                continue
+              fi
+              echo "::error file=$file,line=$line::Potential secret pattern found: $pattern"
+              PATTERN_FOUND=1
               FOUND=1
+            done < <(git grep -nP "$pattern" -- ':!.github' ':!.ci' ':!node_modules' ':!.venv' 2>/dev/null || true)
+            if [ "$PATTERN_FOUND" -eq 1 ]; then
+              echo "::error::Potential secret pattern found: $pattern"
             fi
           done
           if [ "$FOUND" -eq 1 ]; then

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -19,9 +19,22 @@ jobs:
         run: |
           FOUND=0
           for pattern in 'sk-[a-zA-Z0-9]{20,}' 'ghp_[a-zA-Z0-9]{36}' 'AKIA[A-Z0-9]{16}' 'sk-ant-[a-zA-Z0-9]{20,}'; do
-            if git grep -lP "$pattern" -- ':!.github' ':!node_modules' ':!.venv' ':!tests' ':!.ci' 2>/dev/null; then
-              echo "::error::Potential secret pattern found: $pattern"
+            PATTERN_FOUND=0
+            while IFS=: read -r file line content; do
+              case "$file" in
+                .ci/*|.github/*|node_modules/*|.venv/*)
+                  continue
+                  ;;
+              esac
+              if [[ "$content" == *"allow-secret"* ]]; then
+                continue
+              fi
+              echo "::error file=$file,line=$line::Potential secret pattern found: $pattern"
+              PATTERN_FOUND=1
               FOUND=1
+            done < <(git grep -nP "$pattern" -- ':!.github' ':!.ci' ':!node_modules' ':!.venv' 2>/dev/null || true)
+            if [ "$PATTERN_FOUND" -eq 1 ]; then
+              echo "::error::Potential secret pattern found: $pattern"
             fi
           done
           if [ "$FOUND" -eq 1 ]; then

--- a/adapters/base.py
+++ b/adapters/base.py
@@ -481,6 +481,8 @@ class AnthropicAdapter(LLMAdapter):
         - 529 OverloadedError       -> LLMOverloadedError (retryable with backoff)
         - Other APIStatusError      -> LLMAdapterError (generic)
         """
+        from importlib import import_module
+
         from anthropic import (
             APIStatusError,
             RateLimitError,
@@ -489,21 +491,18 @@ class AnthropicAdapter(LLMAdapter):
         # These error types exist in the SDK but may not be re-exported from
         # the public __init__.py in all versions.  Try the public path first,
         # then fall back to the private _exceptions module.
-        try:
-            from anthropic import OverloadedError
-        except ImportError:
-            try:
-                from anthropic._exceptions import OverloadedError
-            except ImportError:
-                OverloadedError = None  # type: ignore[assignment, misc]
-
-        try:
-            from anthropic import RequestTooLargeError
-        except ImportError:
-            try:
-                from anthropic._exceptions import RequestTooLargeError
-            except ImportError:
-                RequestTooLargeError = None  # type: ignore[assignment, misc]
+        anthropic_module = import_module("anthropic")
+        anthropic_exceptions_module = import_module("anthropic._exceptions")
+        overloaded_error_type = getattr(
+            anthropic_module,
+            "OverloadedError",
+            getattr(anthropic_exceptions_module, "OverloadedError", None),
+        )
+        request_too_large_error_type = getattr(
+            anthropic_module,
+            "RequestTooLargeError",
+            getattr(anthropic_exceptions_module, "RequestTooLargeError", None),
+        )
 
         from agents.framework.errors import (
             LLMAdapterError,
@@ -515,11 +514,11 @@ class AnthropicAdapter(LLMAdapter):
         provider = "anthropic"
 
         # 413 — request payload too large (non-retryable)
-        if RequestTooLargeError and isinstance(e, RequestTooLargeError):
+        if request_too_large_error_type and isinstance(e, request_too_large_error_type):
             return LLMRequestTooLargeError(provider=provider, detail=str(e))
 
         # 529 — server overloaded (retryable)
-        if OverloadedError and isinstance(e, OverloadedError):
+        if overloaded_error_type and isinstance(e, overloaded_error_type):
             retry_after = None
             if hasattr(e, "response") and e.response is not None:
                 raw = e.response.headers.get("retry-after")

--- a/adapters/router.py
+++ b/adapters/router.py
@@ -359,8 +359,9 @@ class LLMRouter:
         if allowed:
             chain = [p for p in chain if p in allowed]
             if not chain:
+                classification_value = classification.value if classification else "unknown"
                 raise LLMAdapterError(
-                    f"No available provider for classification={classification.value}. "
+                    f"No available provider for classification={classification_value}. "
                     f"Allowed: {[p.value for p in allowed]}. "
                     f"Available: {[p.value for p in self._fallback_chain]}"
                 )

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -159,8 +159,12 @@ class TitanDashboard:
         if not self.app:
             return
 
-        def render_template(template_name: str, context: dict[str, Any]) -> HTMLResponse:
-            return cast(HTMLResponse, templates.TemplateResponse(template_name, context))
+        def render_template(
+            request: Request,
+            template_name: str,
+            context: dict[str, Any],
+        ) -> HTMLResponse:
+            return cast(HTMLResponse, templates.TemplateResponse(request, template_name, context))
 
         # ====================================================================
         # HTML Routes
@@ -170,6 +174,7 @@ class TitanDashboard:
         async def index(request: Request) -> HTMLResponse:
             """Dashboard home page."""
             return render_template(
+                request,
                 "index.html",
                 {
                     "request": request,
@@ -183,6 +188,7 @@ class TitanDashboard:
         async def agents_page(request: Request) -> HTMLResponse:
             """Agents management page."""
             return render_template(
+                request,
                 "agents.html",
                 {
                     "request": request,
@@ -195,6 +201,7 @@ class TitanDashboard:
         async def topology_page(request: Request) -> HTMLResponse:
             """Topology visualization page."""
             return render_template(
+                request,
                 "topology.html",
                 {
                     "request": request,
@@ -208,6 +215,7 @@ class TitanDashboard:
         async def models_page(request: Request) -> HTMLResponse:
             """Model cognitive signatures page."""
             return render_template(
+                request,
                 "models.html",
                 {
                     "request": request,
@@ -221,6 +229,7 @@ class TitanDashboard:
             sessions = await self._get_inquiry_sessions()
             stats = self._get_inquiry_stats(sessions)
             return render_template(
+                request,
                 "inquiry.html",
                 {
                     "request": request,
@@ -251,6 +260,7 @@ class TitanDashboard:
             )
 
             return render_template(
+                request,
                 "inquiry_detail.html",
                 {
                     "request": request,
@@ -265,6 +275,7 @@ class TitanDashboard:
         async def analysis_page(request: Request) -> HTMLResponse:
             """Contradiction analysis page."""
             return render_template(
+                request,
                 "analysis.html",
                 {
                     "request": request,
@@ -276,6 +287,7 @@ class TitanDashboard:
         async def knowledge_page(request: Request) -> HTMLResponse:
             """Knowledge graph browser page."""
             return render_template(
+                request,
                 "knowledge.html",
                 {
                     "request": request,
@@ -287,6 +299,7 @@ class TitanDashboard:
         async def lexicon_page(request: Request) -> HTMLResponse:
             """Organizational Body Lexicon visualization page."""
             return render_template(
+                request,
                 "lexicon.html",
                 {
                     "request": request,

--- a/dashboard/templates/analysis.html
+++ b/dashboard/templates/analysis.html
@@ -269,27 +269,15 @@
         const section = document.getElementById('results-section');
         const content = document.getElementById('results-content');
 
+        clearElement(content);
         if (result.contradictions.length === 0) {
-            content.innerHTML = '<p>No contradictions detected.</p>';
+            const message = document.createElement('p');
+            message.textContent = 'No contradictions detected.';
+            content.appendChild(message);
         } else {
-            content.innerHTML = result.contradictions.map(c => `
-                <div class="contradiction-card ${c.severity}">
-                    <span class="contradiction-type">${c.contradiction_type}</span>
-                    <span class="severity-badge severity-${c.severity}">${c.severity}</span>
-                    <span style="float: right; color: var(--muted-color);">Confidence: ${Math.round(c.confidence * 100)}%</span>
-                    <p style="margin-top: 1rem;">${c.description}</p>
-                    <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin-top: 1rem;">
-                        <div>
-                            <strong>Statement A:</strong>
-                            <p style="font-style: italic;">"${c.text_a_excerpt}"</p>
-                        </div>
-                        <div>
-                            <strong>Statement B:</strong>
-                            <p style="font-style: italic;">"${c.text_b_excerpt}"</p>
-                        </div>
-                    </div>
-                </div>
-            `).join('');
+            result.contradictions.forEach((contradiction) => {
+                content.appendChild(createContradictionCard(contradiction));
+            });
         }
 
         section.style.display = 'block';
@@ -299,30 +287,117 @@
         const section = document.getElementById('results-section');
         const content = document.getElementById('results-content');
 
-        let html = `<p>Analyzed ${result.stage_pairs_analyzed} stage pairs.</p>`;
+        clearElement(content);
+        const summary = document.createElement('p');
+        summary.textContent = `Analyzed ${result.stage_pairs_analyzed} stage pairs.`;
+        content.appendChild(summary);
 
         if (result.contradictions.length === 0) {
-            html += '<p>No contradictions found between stages.</p>';
+            const message = document.createElement('p');
+            message.textContent = 'No contradictions found between stages.';
+            content.appendChild(message);
         } else {
-            html += result.contradictions.map((c, i) => `
-                <div class="contradiction-card ${c.severity}">
-                    <strong>${c.stage_a}</strong> vs <strong>${c.stage_b}</strong>
-                    <span class="contradiction-type">${c.type}</span>
-                    <span class="severity-badge severity-${c.severity}">${c.severity}</span>
-                    <p>${c.description}</p>
-                    ${result.dialectic_suggestions[i] ? `
-                        <details>
-                            <summary>Suggested Resolution</summary>
-                            <p>${result.dialectic_suggestions[i].synthesis}</p>
-                            <small>Strategy: ${result.dialectic_suggestions[i].strategy}</small>
-                        </details>
-                    ` : ''}
-                </div>
-            `).join('');
+            result.contradictions.forEach((contradiction, index) => {
+                const card = document.createElement('div');
+                card.className = `contradiction-card ${contradiction.severity}`;
+
+                const stageA = document.createElement('strong');
+                stageA.textContent = contradiction.stage_a;
+                card.appendChild(stageA);
+                card.appendChild(document.createTextNode(' vs '));
+                const stageB = document.createElement('strong');
+                stageB.textContent = contradiction.stage_b;
+                card.appendChild(stageB);
+
+                const type = document.createElement('span');
+                type.className = 'contradiction-type';
+                type.textContent = contradiction.type;
+                card.appendChild(type);
+
+                const severity = document.createElement('span');
+                severity.className = `severity-badge severity-${contradiction.severity}`;
+                severity.textContent = contradiction.severity;
+                card.appendChild(severity);
+
+                const description = document.createElement('p');
+                description.textContent = contradiction.description;
+                card.appendChild(description);
+
+                const suggestion = result.dialectic_suggestions[index];
+                if (suggestion) {
+                    const details = document.createElement('details');
+                    const detailsSummary = document.createElement('summary');
+                    detailsSummary.textContent = 'Suggested Resolution';
+                    const synthesis = document.createElement('p');
+                    synthesis.textContent = suggestion.synthesis;
+                    const strategy = document.createElement('small');
+                    strategy.textContent = `Strategy: ${suggestion.strategy}`;
+                    details.appendChild(detailsSummary);
+                    details.appendChild(synthesis);
+                    details.appendChild(strategy);
+                    card.appendChild(details);
+                }
+
+                content.appendChild(card);
+            });
         }
 
-        content.innerHTML = html;
         section.style.display = 'block';
+    }
+
+    function clearElement(element) {
+        while (element.firstChild) {
+            element.removeChild(element.firstChild);
+        }
+    }
+
+    function createContradictionCard(contradiction) {
+        const card = document.createElement('div');
+        card.className = `contradiction-card ${contradiction.severity}`;
+
+        const type = document.createElement('span');
+        type.className = 'contradiction-type';
+        type.textContent = contradiction.contradiction_type;
+        card.appendChild(type);
+
+        const severity = document.createElement('span');
+        severity.className = `severity-badge severity-${contradiction.severity}`;
+        severity.textContent = contradiction.severity;
+        card.appendChild(severity);
+
+        const confidence = document.createElement('span');
+        confidence.style.float = 'right';
+        confidence.style.color = 'var(--muted-color)';
+        confidence.textContent = `Confidence: ${Math.round(contradiction.confidence * 100)}%`;
+        card.appendChild(confidence);
+
+        const description = document.createElement('p');
+        description.style.marginTop = '1rem';
+        description.textContent = contradiction.description;
+        card.appendChild(description);
+
+        const grid = document.createElement('div');
+        grid.style.display = 'grid';
+        grid.style.gridTemplateColumns = '1fr 1fr';
+        grid.style.gap = '1rem';
+        grid.style.marginTop = '1rem';
+        grid.appendChild(createStatementBlock('Statement A:', contradiction.text_a_excerpt));
+        grid.appendChild(createStatementBlock('Statement B:', contradiction.text_b_excerpt));
+        card.appendChild(grid);
+
+        return card;
+    }
+
+    function createStatementBlock(label, excerpt) {
+        const wrapper = document.createElement('div');
+        const strong = document.createElement('strong');
+        strong.textContent = label;
+        const text = document.createElement('p');
+        text.style.fontStyle = 'italic';
+        text.textContent = `"${excerpt}"`;
+        wrapper.appendChild(strong);
+        wrapper.appendChild(text);
+        return wrapper;
     }
 
     function displaySynthesis(thesis, antithesis, result) {

--- a/dashboard/templates/inquiry.html
+++ b/dashboard/templates/inquiry.html
@@ -183,21 +183,55 @@
 
     function updateSessionList(sessions) {
         const tbody = document.getElementById('session-list');
-        tbody.innerHTML = sessions.map(s => `
-            <tr data-session-id="${s.id}">
-                <td><code>${s.id.slice(0, 12)}...</code></td>
-                <td>${s.topic.slice(0, 40)}${s.topic.length > 40 ? '...' : ''}</td>
-                <td>${s.workflow_name}</td>
-                <td><span class="status-badge status-${s.status}">${s.status}</span></td>
-                <td>
-                    <progress value="${s.progress}" max="100"></progress>
-                    <small>${Math.round(s.progress)}%</small>
-                </td>
-                <td>
-                    <a href="/inquiry/${s.id}" class="button outline small">View</a>
-                </td>
-            </tr>
-        `).join('');
+        while (tbody.firstChild) {
+            tbody.removeChild(tbody.firstChild);
+        }
+
+        sessions.forEach((session) => {
+            const row = document.createElement('tr');
+            row.dataset.sessionId = session.id;
+
+            const idCell = document.createElement('td');
+            const code = document.createElement('code');
+            code.textContent = `${session.id.slice(0, 12)}...`;
+            idCell.appendChild(code);
+            row.appendChild(idCell);
+
+            const topicCell = document.createElement('td');
+            topicCell.textContent = `${session.topic.slice(0, 40)}${session.topic.length > 40 ? '...' : ''}`;
+            row.appendChild(topicCell);
+
+            const workflowCell = document.createElement('td');
+            workflowCell.textContent = session.workflow_name;
+            row.appendChild(workflowCell);
+
+            const statusCell = document.createElement('td');
+            const badge = document.createElement('span');
+            badge.className = `status-badge status-${session.status}`;
+            badge.textContent = session.status;
+            statusCell.appendChild(badge);
+            row.appendChild(statusCell);
+
+            const progressCell = document.createElement('td');
+            const progress = document.createElement('progress');
+            progress.value = session.progress;
+            progress.max = 100;
+            const progressLabel = document.createElement('small');
+            progressLabel.textContent = `${Math.round(session.progress)}%`;
+            progressCell.appendChild(progress);
+            progressCell.appendChild(progressLabel);
+            row.appendChild(progressCell);
+
+            const actionsCell = document.createElement('td');
+            const viewLink = document.createElement('a');
+            viewLink.href = `/inquiry/${encodeURIComponent(session.id)}`;
+            viewLink.className = 'button outline small';
+            viewLink.textContent = 'View';
+            actionsCell.appendChild(viewLink);
+            row.appendChild(actionsCell);
+
+            tbody.appendChild(row);
+        });
     }
 
     async function pauseSession(sessionId) {

--- a/dashboard/templates/knowledge.html
+++ b/dashboard/templates/knowledge.html
@@ -306,22 +306,35 @@
         const section = document.getElementById('node-details');
         const content = document.getElementById('node-content');
 
-        content.innerHTML = `
-            <dl>
-                <dt>ID</dt>
-                <dd><code>${node.id}</code></dd>
-                <dt>Label</dt>
-                <dd>${node.label}</dd>
-                <dt>Type</dt>
-                <dd>${node.type}</dd>
-                ${Object.entries(node.properties || {}).map(([k, v]) => `
-                    <dt>${k}</dt>
-                    <dd>${v}</dd>
-                `).join('')}
-            </dl>
-        `;
+        while (content.firstChild) {
+            content.removeChild(content.firstChild);
+        }
+
+        const dl = document.createElement('dl');
+        addDefinition(dl, 'ID', node.id, true);
+        addDefinition(dl, 'Label', node.label);
+        addDefinition(dl, 'Type', node.type);
+        Object.entries(node.properties || {}).forEach(([key, value]) => {
+            addDefinition(dl, key, value);
+        });
+        content.appendChild(dl);
 
         section.style.display = 'block';
+    }
+
+    function addDefinition(dl, term, value, codeValue) {
+        const dt = document.createElement('dt');
+        dt.textContent = term;
+        const dd = document.createElement('dd');
+        if (codeValue) {
+            const code = document.createElement('code');
+            code.textContent = String(value ?? '');
+            dd.appendChild(code);
+        } else {
+            dd.textContent = String(value ?? '');
+        }
+        dl.appendChild(dt);
+        dl.appendChild(dd);
     }
 
     function closeNodeDetails() {
@@ -344,13 +357,31 @@
             const results = await response.json();
 
             document.getElementById('results-count').textContent = `(${results.total_results} found)`;
-            document.getElementById('results-list').innerHTML = results.results.map(r => `
-                <li onclick="highlightNode('${r.key}')">
-                    <span class="result-key">${r.key}</span>
-                    <span class="result-score">${Math.round(r.score * 100)}%</span>
-                    <p class="result-preview">${r.content_preview}</p>
-                </li>
-            `).join('');
+            const resultsList = document.getElementById('results-list');
+            while (resultsList.firstChild) {
+                resultsList.removeChild(resultsList.firstChild);
+            }
+            results.results.forEach((result) => {
+                const item = document.createElement('li');
+                item.addEventListener('click', () => highlightNode(result.key));
+
+                const key = document.createElement('span');
+                key.className = 'result-key';
+                key.textContent = result.key;
+                item.appendChild(key);
+
+                const score = document.createElement('span');
+                score.className = 'result-score';
+                score.textContent = `${Math.round(result.score * 100)}%`;
+                item.appendChild(score);
+
+                const preview = document.createElement('p');
+                preview.className = 'result-preview';
+                preview.textContent = result.content_preview;
+                item.appendChild(preview);
+
+                resultsList.appendChild(item);
+            });
 
             document.getElementById('search-results').style.display = 'block';
         } catch (error) {

--- a/dashboard/templates/models.html
+++ b/dashboard/templates/models.html
@@ -277,7 +277,9 @@
             const data = await response.json();
 
             const tbody = document.getElementById('rankings-body');
-            tbody.innerHTML = '';
+            while (tbody.firstChild) {
+                tbody.removeChild(tbody.firstChild);
+            }
 
             data.models.forEach(model => {
                 const row = document.createElement('tr');
@@ -287,9 +289,14 @@
                 row.appendChild(nameCell);
 
                 const strengthsCell = document.createElement('td');
-                strengthsCell.innerHTML = model.top_strengths
-                    .map(s => `<small>${formatDimension(s.task)}: ${s.score}</small>`)
-                    .join('<br>');
+                model.top_strengths.forEach((strength, index) => {
+                    if (index > 0) {
+                        strengthsCell.appendChild(document.createElement('br'));
+                    }
+                    const small = document.createElement('small');
+                    small.textContent = `${formatDimension(strength.task)}: ${strength.score}`;
+                    strengthsCell.appendChild(small);
+                });
                 row.appendChild(strengthsCell);
 
                 const avgCell = document.createElement('td');
@@ -310,7 +317,9 @@
             const data = await response.json();
 
             const tbody = document.getElementById('preferences-body');
-            tbody.innerHTML = '';
+            while (tbody.firstChild) {
+                tbody.removeChild(tbody.firstChild);
+            }
 
             Object.entries(data).forEach(([taskType, prefs]) => {
                 const row = document.createElement('tr');
@@ -320,7 +329,9 @@
                 row.appendChild(taskCell);
 
                 const preferredCell = document.createElement('td');
-                preferredCell.innerHTML = `<strong>${formatModelName(prefs.preferred || 'None')}</strong>`;
+                const preferred = document.createElement('strong');
+                preferred.textContent = formatModelName(prefs.preferred || 'None');
+                preferredCell.appendChild(preferred);
                 row.appendChild(preferredCell);
 
                 const altsCell = document.createElement('td');
@@ -374,35 +385,84 @@
             // Summary
             const summaryDiv = document.getElementById('comparison-summary');
             const winner = data.summary.overall_winner;
-            summaryDiv.innerHTML = `
-                <strong>Result:</strong>
-                ${formatModelName(data.model_a)}: ${data.summary.model_a_wins} wins |
-                ${formatModelName(data.model_b)}: ${data.summary.model_b_wins} wins |
-                Ties: ${data.summary.ties}
-                <br>
-                <strong>Overall Winner:</strong> ${winner === 'tie' ? 'Tie' : formatModelName(winner)}
-            `;
+            while (summaryDiv.firstChild) {
+                summaryDiv.removeChild(summaryDiv.firstChild);
+            }
+            const resultLabel = document.createElement('strong');
+            resultLabel.textContent = 'Result:';
+            summaryDiv.appendChild(resultLabel);
+            summaryDiv.appendChild(document.createTextNode(
+                ` ${formatModelName(data.model_a)}: ${data.summary.model_a_wins} wins | ` +
+                `${formatModelName(data.model_b)}: ${data.summary.model_b_wins} wins | ` +
+                `Ties: ${data.summary.ties}`
+            ));
+            summaryDiv.appendChild(document.createElement('br'));
+            const winnerLabel = document.createElement('strong');
+            winnerLabel.textContent = 'Overall Winner:';
+            summaryDiv.appendChild(winnerLabel);
+            summaryDiv.appendChild(document.createTextNode(
+                ` ${winner === 'tie' ? 'Tie' : formatModelName(winner)}`
+            ));
 
             // Details
             const detailsDiv = document.getElementById('comparison-details');
-            detailsDiv.innerHTML = '<table><thead><tr><th>Dimension</th><th>Comparison</th></tr></thead><tbody>' +
-                data.dimensions.map(d => `
-                    <tr>
-                        <td>${formatDimension(d.dimension)}</td>
-                        <td>
-                            <div class="comparison-bar">
-                                <div class="comparison-bar-a" style="width: ${d.model_a_score * 10}px;"
-                                     title="${formatModelName(data.model_a)}: ${d.model_a_score}"></div>
-                                <span class="${d.winner === data.model_a ? 'winner' : ''}">${d.model_a_score}</span>
-                                <span>vs</span>
-                                <span class="${d.winner === data.model_b ? 'winner' : ''}">${d.model_b_score}</span>
-                                <div class="comparison-bar-b" style="width: ${d.model_b_score * 10}px;"
-                                     title="${formatModelName(data.model_b)}: ${d.model_b_score}"></div>
-                            </div>
-                        </td>
-                    </tr>
-                `).join('') +
-                '</tbody></table>';
+            while (detailsDiv.firstChild) {
+                detailsDiv.removeChild(detailsDiv.firstChild);
+            }
+            const table = document.createElement('table');
+            const thead = document.createElement('thead');
+            const headerRow = document.createElement('tr');
+            ['Dimension', 'Comparison'].forEach((label) => {
+                const th = document.createElement('th');
+                th.textContent = label;
+                headerRow.appendChild(th);
+            });
+            thead.appendChild(headerRow);
+            table.appendChild(thead);
+
+            const tbody = document.createElement('tbody');
+            data.dimensions.forEach((dimension) => {
+                const row = document.createElement('tr');
+                const dimCell = document.createElement('td');
+                dimCell.textContent = formatDimension(dimension.dimension);
+                row.appendChild(dimCell);
+
+                const comparisonCell = document.createElement('td');
+                const bar = document.createElement('div');
+                bar.className = 'comparison-bar';
+
+                const barA = document.createElement('div');
+                barA.className = 'comparison-bar-a';
+                barA.style.width = `${dimension.model_a_score * 10}px`;
+                barA.title = `${formatModelName(data.model_a)}: ${dimension.model_a_score}`;
+                bar.appendChild(barA);
+
+                const scoreA = document.createElement('span');
+                scoreA.className = dimension.winner === data.model_a ? 'winner' : '';
+                scoreA.textContent = dimension.model_a_score;
+                bar.appendChild(scoreA);
+
+                const separator = document.createElement('span');
+                separator.textContent = 'vs';
+                bar.appendChild(separator);
+
+                const scoreB = document.createElement('span');
+                scoreB.className = dimension.winner === data.model_b ? 'winner' : '';
+                scoreB.textContent = dimension.model_b_score;
+                bar.appendChild(scoreB);
+
+                const barB = document.createElement('div');
+                barB.className = 'comparison-bar-b';
+                barB.style.width = `${dimension.model_b_score * 10}px`;
+                barB.title = `${formatModelName(data.model_b)}: ${dimension.model_b_score}`;
+                bar.appendChild(barB);
+
+                comparisonCell.appendChild(bar);
+                row.appendChild(comparisonCell);
+                tbody.appendChild(row);
+            });
+            table.appendChild(tbody);
+            detailsDiv.appendChild(table);
         } catch (err) {
             console.error('Error comparing models:', err);
         }

--- a/docs/reference/modular-synthesis-architecture.md
+++ b/docs/reference/modular-synthesis-architecture.md
@@ -1,0 +1,140 @@
+# Reference: Modular Synthesis Multi-Agent Architecture
+
+**Source Atom:** `prompt-1dd4e88daf85`
+**Origin:** ChatGPT thread "Swarm of AI" (2025-08-28)
+**Type:** Architecture synthesis document
+**Ingested:** 2026-04-23
+
+---
+
+## Summary
+
+This document captures the 9-recommendation architecture proposed in the "Swarm of AI" ChatGPT thread, which synthesized multi-agent AI system design through the lens of modular synthesis (oscillator/filter/patch-cable metaphors). The original prompt explored how concepts from analog synthesizer design -- where specialized modules (oscillators, filters, envelopes, VCAs) are composed via patch cables into arbitrary signal chains -- could inform the architecture of multi-agent AI systems.
+
+---
+
+## The 9 Recommendations
+
+### 1. Agents as Specialized Modules (Oscillator/Filter Metaphor)
+
+Each agent functions as a specialized signal-processing module analogous to components in a modular synthesizer:
+
+- **Oscillators** (generators): Agents that produce raw output -- researchers, content generators, code writers. They create the fundamental signal.
+- **Filters** (transformers): Agents that refine, review, or constrain output -- reviewers, editors, security scanners. They shape the signal.
+- **Envelopes** (controllers): Agents that modulate other agents' behavior over time -- orchestrators, schedulers, budget managers. They control the amplitude and timing.
+- **Mixers** (combiners): Agents that merge multiple outputs -- synthesizers, consensus builders, report assemblers. They blend signals.
+
+The key insight: modules should be maximally specialized and minimally coupled. Each module has a defined input interface and output interface. Composition happens externally via patching, not internally via shared state.
+
+### 2. Orchestration as Patching (DAG + Cycles)
+
+Agent composition should follow the modular synthesis patching model:
+
+- **Patch cables** = directed edges in a computation graph
+- **DAGs** handle feed-forward workflows (research -> synthesis -> review -> publish)
+- **Cycles** handle iterative refinement (generate -> test -> feedback -> regenerate)
+- **Self-patching** = agents that modify the graph topology during execution
+- **LangGraph** cited as the closest implementation of this pattern in the AI agent ecosystem
+
+The patching metaphor separates the "what agents do" (module definition) from "how agents connect" (topology definition). This separation enables runtime reconfiguration without modifying agent code.
+
+### 3. Blackboard Pattern for Shared State
+
+A blackboard architecture provides shared state without direct agent-to-agent coupling:
+
+- **Hot tier (Redis):** Active session state, real-time coordination signals, pub/sub event channels. Sub-millisecond reads. Ephemeral.
+- **Cold tier (PostgreSQL):** Audit logs, decision history, accumulated knowledge. Durable. Queryable. Compliance-ready.
+
+Agents write findings and read context from the blackboard rather than passing messages directly. This decouples agent execution order from data flow and enables late-joining agents to catch up on accumulated state.
+
+### 4. Hierarchical + Decentralized Collaboration
+
+The architecture should support both organizational models simultaneously:
+
+- **Hierarchical mode:** A coordinator agent delegates subtasks to specialist agents, collects results, and synthesizes. Appropriate for well-structured tasks with clear decomposition.
+- **Decentralized mode:** Agents operate autonomously, sharing findings through the blackboard. No central coordinator. Appropriate for exploration, brainstorming, and tasks where the structure is unknown in advance.
+- **Hybrid transitions:** The system should switch between hierarchical and decentralized modes based on task characteristics. Exploration phases benefit from decentralization; synthesis phases benefit from hierarchy.
+
+### 5. Budget-Aware Scheduling (CFO Agent)
+
+A dedicated budget management agent (the "CFO") enforces cost discipline:
+
+- Tracks per-agent, per-session, and per-workflow API costs
+- Maintains pricing tables for all LLM providers
+- Estimates cost before authorizing LLM calls
+- Enforces budget thresholds with configurable actions (warn, throttle, block)
+- Reports cost-per-feature and cost-per-agent metrics
+- Routes tasks to cheaper models/providers when budget is constrained
+
+The CFO operates as both an agent (capable of reasoning about cost optimization) and an infrastructure layer (enforcing hard limits regardless of agent intent).
+
+### 6. Secure Code Execution Sandboxing
+
+When agents generate and execute code, the execution environment must be sandboxed:
+
+- Process-level isolation (minimum): separate processes with restricted filesystem access
+- Container-level isolation (standard): Docker containers with resource limits, network restrictions, read-only filesystems
+- VM-level isolation (maximum): lightweight VMs (Firecracker, gVisor) for untrusted code execution
+- Runtime selection based on trust level: trusted agents get process isolation; untrusted agents get VM isolation
+
+The sandboxing layer should be transparent to the agent -- the same agent code runs in any isolation tier. The runtime selector chooses the appropriate tier based on the agent's trust level, the task's risk classification, and the execution environment's capabilities.
+
+### 7. HITL Workflows for High-Stakes Actions
+
+Human-in-the-loop approval gates prevent autonomous execution of high-consequence actions:
+
+- **Risk classification:** Every agent action is classified as low/medium/high risk before execution
+- **Auto-approve:** Low-risk actions execute immediately (reading files, querying APIs, generating text)
+- **Notify-and-proceed:** Medium-risk actions execute but notify the human (modifying files, sending messages)
+- **Block-until-approved:** High-risk actions halt until a human explicitly approves (deploying code, spending money, deleting data, external communications)
+- **Approval channels:** WebSocket for real-time dashboards, email/Slack for async workflows, CLI prompts for interactive sessions
+
+HITL is structural, not optional. The absence of HITL gates makes multi-agent systems unusable for any task with real-world consequences.
+
+### 8. Observability Pipeline for RLHF
+
+Every agent interaction should be instrumented for reinforcement learning from human feedback:
+
+- **Capture:** Log every LLM call with full context (prompt, response, model, latency, cost, tool calls)
+- **Annotate:** Human reviewers label interactions as helpful/unhelpful, correct/incorrect, safe/unsafe
+- **Aggregate:** Build preference datasets from annotated interactions
+- **Train:** Use preference data to fine-tune local models (DPO, RLHF) or refine prompt templates
+- **Deploy:** Updated models/prompts feed back into the agent system
+- **Measure:** Track quality metrics (acceptance rate, retry rate, self-correction count) to validate improvement
+
+The observability pipeline should be append-only, immutable, and queryable. It serves dual purposes: operational monitoring (is the system working?) and learning (is the system improving?).
+
+### 9. Comprehensive Agentic Test Suite
+
+Multi-agent systems require testing at multiple levels:
+
+- **Unit tests:** Individual agent behavior given specific inputs
+- **Integration tests:** Agent-to-agent communication, blackboard reads/writes, tool invocations
+- **Topology tests:** Correct behavior across all supported coordination patterns
+- **Adversarial tests:** Agent robustness against malicious inputs, prompt injection, resource exhaustion
+- **Chaos tests:** System behavior under failure conditions (agent crashes, network partitions, provider outages)
+- **End-to-end tests:** Full workflow execution from task input to final output
+- **Performance tests:** Latency, throughput, and cost under load
+- **Safety tests:** HITL gates trigger correctly, RBAC enforces correctly, budget limits hold
+
+The test suite is not optional infrastructure -- it is a structural requirement that validates the compositional guarantees the modular architecture claims to provide.
+
+---
+
+## Cross-Reference to ORGANVM
+
+This atom was evaluated against the current ORGANVM implementation on 2026-04-23. The gap analysis is at:
+
+`~/Workspace/meta-organvm/organvm-corpvs-testamentvm/data/atoms/multi-agent-architecture-gap-analysis.md`
+
+**Key finding:** 8 of 9 recommendations are fully or substantially implemented in agentic-titan. The primary gap is closing the RLHF feedback loop (recommendation 8) -- the observability infrastructure exists but does not yet feed back into systematic behavior modification.
+
+---
+
+## Provenance
+
+- **Thread:** "Swarm of AI" (ChatGPT, 2025-08-28)
+- **Atom ID:** `prompt-1dd4e88daf85`
+- **Priority:** P0
+- **Domain:** architecture, multi-agent, orchestration
+- **Tags:** `modular-synthesis`, `multi-agent`, `DAG`, `blackboard`, `RLHF`, `sandboxing`, `HITL`, `budget`, `testing`

--- a/gateway/http_gateway.py
+++ b/gateway/http_gateway.py
@@ -19,7 +19,7 @@ from typing import Any
 
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 logger = logging.getLogger("titan.gateway")
 
@@ -57,27 +57,29 @@ class InquiryRequest(BaseModel):
 
 
 class TaskResult(BaseModel):
-    taskId: str
+    model_config = ConfigDict(populate_by_name=True)
+
+    task_id: str = Field(alias="taskId")
     status: str  # "completed" | "failed" | "timeout"
     result: str | None = None
     model: str | None = None
-    agentType: str | None = None
+    agent_type: str | None = Field(default=None, alias="agentType")
 
 
 # ---------------------------------------------------------------------------
 # Lazy MCP tool imports — avoids startup failure if titan_mcp deps missing
 # ---------------------------------------------------------------------------
 
-_mcp_server = None
+_mcp_server: Any | None = None
 
 
-def _get_server():
+def _get_server() -> Any:
     global _mcp_server
     if _mcp_server is None:
         try:
-            from titan_mcp.server import MCPServer
+            from titan_mcp.server import TitanMCPServer
 
-            _mcp_server = MCPServer()
+            _mcp_server = TitanMCPServer()
         except ImportError as e:
             logger.error(f"Cannot import titan_mcp: {e}")
             raise HTTPException(
@@ -87,23 +89,54 @@ def _get_server():
     return _mcp_server
 
 
+async def _call_tool(name: str, arguments: dict[str, Any]) -> Any:
+    from titan_mcp.server import MCPRequest
+
+    response = await _get_server().handle_request(
+        MCPRequest(
+            jsonrpc="2.0",
+            id=str(uuid.uuid4()),
+            method="tools/call",
+            params={"name": name, "arguments": arguments},
+        )
+    )
+    if response.error:
+        raise HTTPException(status_code=500, detail=response.error.get("message", "MCP error"))
+    return response.result
+
+
+async def _read_resource(uri: str) -> Any:
+    from titan_mcp.server import MCPRequest
+
+    response = await _get_server().handle_request(
+        MCPRequest(
+            jsonrpc="2.0",
+            id=str(uuid.uuid4()),
+            method="resources/read",
+            params={"uri": uri},
+        )
+    )
+    if response.error:
+        raise HTTPException(status_code=500, detail=response.error.get("message", "MCP error"))
+    return response.result
+
+
 # ---------------------------------------------------------------------------
 # Endpoints
 # ---------------------------------------------------------------------------
 
 
 @app.get("/health")
-async def health():
+async def health() -> dict[str, bool | str]:
     return {"ok": True, "service": "titan-gateway"}
 
 
 @app.post("/api/titan/route-task", response_model=TaskResult)
-async def route_task(req: RouteTaskRequest):
-    server = _get_server()
+async def route_task(req: RouteTaskRequest) -> TaskResult:
     task_id = str(uuid.uuid4())
 
     try:
-        result = await server.handle_tool_call(
+        result = await _call_tool(
             "route_cognitive_task",
             {"task_description": req.query, "context": req.context or ""},
         )
@@ -120,12 +153,11 @@ async def route_task(req: RouteTaskRequest):
 
 
 @app.post("/api/titan/inquiry", response_model=TaskResult)
-async def inquiry(req: InquiryRequest):
-    server = _get_server()
+async def inquiry(req: InquiryRequest) -> TaskResult:
     task_id = str(uuid.uuid4())
 
     try:
-        result = await server.handle_tool_call(
+        result = await _call_tool(
             "start_inquiry",
             {"topic": req.question, "scope": req.scope or "general"},
         )
@@ -140,10 +172,9 @@ async def inquiry(req: InquiryRequest):
 
 
 @app.get("/api/titan/topology")
-async def topology():
-    server = _get_server()
+async def topology() -> dict[str, Any]:
     try:
-        result = await server.handle_resource_read("topology://current")
+        result = await _read_resource("titan://topology/current")
         return {"ok": True, "topology": result}
     except Exception as e:
         logger.exception("topology read failed")
@@ -161,7 +192,7 @@ def _extract_text(result: Any) -> str | None:
     if isinstance(result, dict):
         for key in ("text", "result", "content", "response"):
             if key in result and isinstance(result[key], str):
-                return result[key]
+                return str(result[key])
         # MCP tool results have content array
         contents = result.get("content", [])
         if isinstance(contents, list):

--- a/hive/__init__.py
+++ b/hive/__init__.py
@@ -16,11 +16,6 @@ from hive.analyzer import (
     TaskAnalyzer,
     analyze_task,
 )
-from hive.conflict import (
-    ConflictDetector,
-    ConflictPair,
-    SEMANTIC_OPPOSITES,
-)
 from hive.assembly import (
     AssemblyEvent,
     AssemblyManager,
@@ -29,15 +24,20 @@ from hive.assembly import (
     StabilityMetrics,
     TerritorizationType,
 )
-from hive.emergence import (
-    EmergenceDetector,
-    EmergenceResult,
+from hive.conflict import (
+    SEMANTIC_OPPOSITES,
+    ConflictDetector,
+    ConflictPair,
 )
 from hive.criticality import (
     CriticalityMetrics,
     CriticalityMonitor,
     CriticalityState,
     PhaseTransition,
+)
+from hive.emergence import (
+    EmergenceDetector,
+    EmergenceResult,
 )
 from hive.events import (
     Event,

--- a/hive/experiments/convergence.py
+++ b/hive/experiments/convergence.py
@@ -254,6 +254,7 @@ class ConvergenceExperiment:
         # --- Neighborhood (k=7 topological neighbors) ---
         neighborhood = TopologicalNeighborhood(
             neighbor_count=self._neighbor_count,
+            recency_decay=0.0,
         )
 
         # Generate per-agent contributions and register in neighborhood

--- a/hive/memory.py
+++ b/hive/memory.py
@@ -23,7 +23,7 @@ import uuid
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any
+from typing import Any, cast
 
 logger = logging.getLogger("titan.hive.memory")
 
@@ -188,7 +188,8 @@ class HiveMind:
         try:
             import redis.asyncio as redis
 
-            self._redis = redis.from_url(
+            from_url = cast(Any, redis.from_url)
+            self._redis = from_url(
                 self.config.redis_url,
                 db=self.config.redis_db,
                 socket_connect_timeout=self.config.connection_timeout,

--- a/hive/neighborhood.py
+++ b/hive/neighborhood.py
@@ -191,6 +191,11 @@ class TopologicalNeighborhood:
         self._secondary_cache: dict[str, list[str]] = {}
         self._cache_valid = False
 
+    def _invalidate_cache(self) -> None:
+        self._neighbor_cache.clear()
+        self._secondary_cache.clear()
+        self._cache_valid = False
+
     @property
     def neighbor_count(self) -> int:
         """Number of neighbors per agent."""
@@ -218,7 +223,7 @@ class TopologicalNeighborhood:
             metadata=metadata or {},
         )
         self._profiles[agent_id] = profile
-        self._cache_valid = False
+        self._invalidate_cache()
 
         logger.debug(f"Registered agent in neighborhood: {agent_id}")
         return profile
@@ -234,7 +239,7 @@ class TopologicalNeighborhood:
         """
         if agent_id in self._profiles:
             del self._profiles[agent_id]
-            self._cache_valid = False
+            self._invalidate_cache()
             return True
         return False
 
@@ -268,7 +273,7 @@ class TopologicalNeighborhood:
             profile.capabilities = capabilities
 
         profile.last_seen = datetime.now(UTC)
-        self._cache_valid = False
+        self._invalidate_cache()
 
         return profile
 
@@ -309,7 +314,7 @@ class TopologicalNeighborhood:
         if len(self._interactions) > self._max_history:
             self._interactions = self._interactions[-self._max_history :]
 
-        self._cache_valid = False
+        self._invalidate_cache()
 
         logger.debug(
             f"Recorded interaction: {agent_a} <-> {agent_b} "
@@ -340,22 +345,22 @@ class TopologicalNeighborhood:
             List of neighbor agent IDs.
         """
         if layer == NeighborLayer.PRIMARY:
-            if not force_recalculate and self._cache_valid:
-                if agent_id in self._neighbor_cache:
-                    return self._neighbor_cache[agent_id]
+            if not force_recalculate and self._cache_valid and agent_id in self._neighbor_cache:
+                return self._neighbor_cache[agent_id]
 
             neighbors = self.calculate_neighbors(agent_id)
             self._neighbor_cache[agent_id] = neighbors
+            self._cache_valid = True
             return neighbors
 
         elif layer == NeighborLayer.SECONDARY:
-            if not force_recalculate and self._cache_valid:
-                if agent_id in self._secondary_cache:
-                    return self._secondary_cache[agent_id]
+            if not force_recalculate and self._cache_valid and agent_id in self._secondary_cache:
+                return self._secondary_cache[agent_id]
 
             # Secondary layer: more neighbors with weaker connections
             neighbors = self._calculate_secondary_neighbors(agent_id)
             self._secondary_cache[agent_id] = neighbors
+            self._cache_valid = True
             return neighbors
 
         elif layer == NeighborLayer.TERTIARY:

--- a/hive/stigmergy.py
+++ b/hive/stigmergy.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
 from enum import StrEnum
 from typing import Any
@@ -388,30 +388,50 @@ class PheromoneField:
         """
         result: list[PheromoneTrace] = []
 
-        # Determine which locations to scan
-        if region.locations is None:
-            # Full-field sensing
+        region_locations = getattr(region, "locations", None)
+        transition_buffer = getattr(region, "transition_buffer", None)
+        invariant_types = getattr(region, "invariant_types", None)
+
+        if region_locations is None or transition_buffer is not None or invariant_types:
             locations_to_scan = list(self._traces.keys())
         else:
             locations_to_scan = [
-                loc for loc in region.locations
+                loc for loc in region_locations
                 if loc in self._traces
             ]
 
         min_intensity = getattr(region, "min_intensity", 0.0)
-        allowed_types = getattr(region, "trace_types", None)
 
         for location in locations_to_scan:
             location_traces = self._traces[location]
             for ttype, traces in location_traces.items():
-                if allowed_types and str(ttype) not in allowed_types:
-                    continue
                 for trace in traces:
-                    if (
-                        not trace.is_expired
-                        and trace.intensity >= min_intensity
-                    ):
+                    if trace.is_expired:
+                        continue
+
+                    extra_type = trace.payload.get("atom_type")
+                    is_invariant = region.is_invariant_type(ttype, extra_type)
+                    if is_invariant:
                         result.append(trace)
+                        continue
+
+                    if not region.allows_trace_type(ttype, extra_type):
+                        continue
+
+                    is_local = region_locations is None or location in region_locations
+                    visible_intensity = trace.intensity
+                    if not is_local:
+                        if transition_buffer is None or transition_buffer <= 0.0:
+                            continue
+                        visible_intensity *= transition_buffer
+
+                    if visible_intensity < min_intensity:
+                        continue
+
+                    if visible_intensity == trace.intensity:
+                        result.append(trace)
+                    else:
+                        result.append(replace(trace, intensity=visible_intensity))
 
         return result
 

--- a/hive/topology.py
+++ b/hive/topology.py
@@ -85,23 +85,41 @@ class SensingRegion:
 
     locations: frozenset[str] | None = None  # None = full field
     trace_types: frozenset[str] | None = None  # None = all types
+    invariant_types: frozenset[str] | None = None  # Bypass topology/type gates
     min_intensity: float = 0.0
     max_radius: int | None = None  # Hop-based radius from agent position
+    transition_buffer: float | None = None  # Foreign non-invariant attenuation
 
     @staticmethod
-    def full_field(min_intensity: float = 0.0) -> SensingRegion:
+    def full_field(
+        min_intensity: float = 0.0,
+        *,
+        trace_types: set[str] | None = None,
+        invariant_types: set[str] | None = None,
+    ) -> SensingRegion:
         """Full-field sensing — perceive all locations and types."""
-        return SensingRegion(min_intensity=min_intensity)
+        return SensingRegion(
+            trace_types=_freeze_or_none(trace_types),
+            invariant_types=_freeze_or_none(invariant_types),
+            min_intensity=min_intensity,
+        )
 
     @staticmethod
     def restricted(
         locations: set[str],
         min_intensity: float = 0.0,
+        *,
+        trace_types: set[str] | None = None,
+        invariant_types: set[str] | None = None,
+        transition_buffer: float | None = None,
     ) -> SensingRegion:
         """Restricted sensing — perceive only specific locations."""
         return SensingRegion(
             locations=frozenset(locations),
+            trace_types=_freeze_or_none(trace_types),
+            invariant_types=_freeze_or_none(invariant_types),
             min_intensity=min_intensity,
+            transition_buffer=transition_buffer,
         )
 
     def contains_location(self, location: str) -> bool:
@@ -109,6 +127,43 @@ class SensingRegion:
         if self.locations is None:
             return True
         return location in self.locations
+
+    def is_invariant_type(self, trace_type: object, *extra_keys: object) -> bool:
+        """Check whether a trace type bypasses topology and type filters."""
+        if self.invariant_types is None:
+            return False
+        return bool(self._type_keys(trace_type, *extra_keys) & self.invariant_types)
+
+    def allows_trace_type(self, trace_type: object, *extra_keys: object) -> bool:
+        """Check whether a non-invariant trace type is visible."""
+        if self.trace_types is None:
+            return True
+        return bool(self._type_keys(trace_type, *extra_keys) & self.trace_types)
+
+    def next_transition_buffer(self, step: float = 0.25) -> SensingRegion:
+        """Return a copy with the transition buffer advanced toward full pass-through."""
+        if self.transition_buffer is None:
+            return self
+        return SensingRegion(
+            locations=self.locations,
+            trace_types=self.trace_types,
+            invariant_types=self.invariant_types,
+            min_intensity=self.min_intensity,
+            max_radius=self.max_radius,
+            transition_buffer=min(1.0, self.transition_buffer + step),
+        )
+
+    @staticmethod
+    def _type_keys(trace_type: object, *extra_keys: object) -> frozenset[str]:
+        keys = {str(getattr(trace_type, "value", trace_type))}
+        for key in extra_keys:
+            if key is not None:
+                keys.add(str(getattr(key, "value", key)))
+        return frozenset(keys)
+
+
+def _freeze_or_none(values: set[str] | None) -> frozenset[str] | None:
+    return frozenset(values) if values is not None else None
 
 
 @dataclass
@@ -1115,10 +1170,25 @@ class FissionFusionTopology(BaseTopology):
     """
 
     topology_type = TopologyType.FISSION_FUSION
+    DEFAULT_INVARIANT_TYPES = frozenset(
+        {"collaboration", "c:sync", "c:ack", "c:yield", "c:delegate"}
+    )
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        invariant_types: set[str] | None = None,
+        transition_buffer_step: float = 0.25,
+    ) -> None:
         super().__init__()
         self.clusters: dict[str, list[str]] = {}  # cluster_id -> list of agent_ids
+        self.invariant_types = (
+            frozenset(invariant_types)
+            if invariant_types is not None
+            else self.DEFAULT_INVARIANT_TYPES
+        )
+        self.transition_buffer_step = transition_buffer_step
+        self._transition_buffer: float | None = None
+        self._transition_home_locations: dict[str, frozenset[str]] = {}
 
     def add_agent(
         self,
@@ -1152,6 +1222,7 @@ class FissionFusionTopology(BaseTopology):
 
     def fission(self, cluster_id: str, new_cluster_id: str, agent_ids: list[str]) -> None:
         """Split a group of agents into a new cluster."""
+        self._clear_transition_buffer()
         if cluster_id not in self.clusters:
             return
 
@@ -1174,6 +1245,8 @@ class FissionFusionTopology(BaseTopology):
         if source_cluster_id not in self.clusters:
             return
 
+        source_agents = set(self.clusters[source_cluster_id])
+        target_agents = set(self.clusters.get(target_cluster_id, []))
         agents = self.clusters.pop(source_cluster_id)
         for aid in agents:
             if target_cluster_id not in self.clusters:
@@ -1181,6 +1254,40 @@ class FissionFusionTopology(BaseTopology):
             self.clusters[target_cluster_id].append(aid)
             self.nodes[aid].metadata["cluster_id"] = target_cluster_id
             self._rebuild_neighbors(aid)
+        self._start_transition_buffer(source_agents, target_agents)
+
+    def _start_transition_buffer(
+        self,
+        source_agents: set[str],
+        target_agents: set[str],
+    ) -> None:
+        """Remember pre-fusion sensing boundaries for the merge window."""
+        if not source_agents or not target_agents:
+            self._clear_transition_buffer()
+            return
+
+        self._transition_buffer = 0.0
+        self._transition_home_locations = {
+            agent_id: frozenset(source_agents) for agent_id in source_agents
+        }
+        self._transition_home_locations.update(
+            {agent_id: frozenset(target_agents) for agent_id in target_agents}
+        )
+
+    def advance_transition_buffer(self, step: float | None = None) -> float | None:
+        """Advance merge-window attenuation toward full pass-through."""
+        if self._transition_buffer is None:
+            return None
+        increment = self.transition_buffer_step if step is None else step
+        self._transition_buffer = min(1.0, self._transition_buffer + increment)
+        if self._transition_buffer >= 1.0:
+            self._clear_transition_buffer()
+            return None
+        return self._transition_buffer
+
+    def _clear_transition_buffer(self) -> None:
+        self._transition_buffer = None
+        self._transition_home_locations.clear()
 
     def _rebuild_neighbors(self, agent_id: str) -> None:
         """Update neighbor lists after fission/fusion."""
@@ -1249,11 +1356,17 @@ class FissionFusionTopology(BaseTopology):
         node = self.nodes.get(agent_id)
         if not node:
             return SensingRegion.restricted({agent_id})
+        if self._transition_buffer is not None and agent_id in self._transition_home_locations:
+            return SensingRegion.restricted(
+                set(self._transition_home_locations[agent_id]),
+                invariant_types=set(self.invariant_types),
+                transition_buffer=self._transition_buffer,
+            )
         cluster_id = node.metadata.get("cluster_id", "main")
         members = self.clusters.get(cluster_id, [])
         locations = {agent_id}
         locations.update(members)
-        return SensingRegion.restricted(locations)
+        return SensingRegion.restricted(locations, invariant_types=set(self.invariant_types))
 
 
 class StigmergicTopology(BaseTopology):

--- a/plans/2026-04-21-dependency-fix-and-cleanup.md
+++ b/plans/2026-04-21-dependency-fix-and-cleanup.md
@@ -1,0 +1,37 @@
+# agentic-titan: Dependency Fix & Cleanup
+
+**Date:** 2026-04-21
+**Status:** EXECUTED
+
+## Context
+agentic-titan had a pydantic-core version mismatch (system Python: pydantic 2.13.2 vs pydantic-core 2.46.2) blocking 57+ test files from collecting (only 313 of ~1,561 tests loaded). One stale remote branch remained from merged PR #39.
+
+## Plan (logical order)
+
+### 1. Fix pydantic-core dependency mismatch
+- Created project `.venv` (was running against system Python — root cause of version skew)
+- Installed `pip install -e ".[dev,dashboard]"` for full test coverage
+- Result: pydantic 2.13.3 + pydantic-core 2.46.3 (matched pair)
+
+### 2. Fix test failures
+- **Bug 1:** `train()` method used `"test" in str(filepath)` which matched pytest's temp directory path, skipping all test fixture files. Fixed to `"test" in filepath.name`.
+- **Bug 2:** Test asserted `type_annotations` pattern detection, but extraction logic was specified (PatternType.TYPING enum exists, StyleProfile.type_annotations field exists) but never wired into `_extract_idiom_patterns`. Added AST-based return-annotation detection.
+
+### 3. Run full test suite
+- Before: 313 collected, 57 errors, 1 failure
+- After: 1,561 collected, 0 errors, 1,544 passed, 18 skipped
+
+### 4. Clean up stale remote branch
+- Deleted `feat/local-inference-f22-f23-f24` (PR #39 merged 2026-03-08)
+
+## Pre-existing issues observed (not addressed — scope discipline)
+- `hashlib`, `json` unused imports (lines 16-17)
+- `_extract_naming_patterns` is a stub (records stats, returns `[]`)
+- `max(cases, key=cases.get)` Pyright type error (line 210)
+- `get_style_context()` calls `StyleAdapter.get_prompt_context()` which doesn't exist (line 267) — will raise AttributeError at runtime
+
+## Verification
+- `python3 -c "import pydantic; print(pydantic.VERSION)"` — 2.13.3, no SystemError
+- `pytest --co -q` — 1,561 collected, 0 errors
+- `pytest -q` — 1,544 passed, 18 skipped
+- `git branch -r` — only `origin/main`

--- a/tests/chaos/test_fission_fusion_chaos.py
+++ b/tests/chaos/test_fission_fusion_chaos.py
@@ -12,7 +12,7 @@ machine transitions, windowed gates, cooldown enforcement).
 from __future__ import annotations
 
 import uuid
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, PropertyMock
 
 import pytest
@@ -20,7 +20,6 @@ import pytest
 from hive.conflict import ConflictDetector
 from hive.criticality import CriticalityMetrics, CriticalityMonitor, CriticalityState
 from hive.fission_fusion import (
-    Cluster,
     FissionFusionManager,
     FissionFusionMetrics,
     FissionFusionState,
@@ -431,7 +430,7 @@ class TestFullEmergenceLoop:
     """Test the complete crisis resolution pipeline with real components."""
 
     async def test_conflict_driven_full_loop(self):
-        """Real opposing traces -> ConflictDetector -> crisis rises -> FUSION -> clear -> FISSION."""
+        """Real opposing traces trigger fusion, then clear and recover to fission."""
         detector = ConflictDetector(intensity_threshold=0.5)
         mgr = _make_manager(conflict_detector=detector)
 
@@ -477,7 +476,7 @@ class TestFullEmergenceLoop:
         assert mgr.state == FissionFusionState.FISSION
 
     async def test_crisis_level_resolution_priority(self):
-        """Verify 3-tier resolution: manual > criticality > preserved, conflict floor always applies."""
+        """Verify crisis priority tiers and the conflict floor."""
         monitor = MagicMock(spec=CriticalityMonitor)
         type(monitor).current_state = PropertyMock(return_value=CriticalityState.SUPERCRITICAL)
         type(monitor).current_metrics = PropertyMock(

--- a/tests/dashboard/test_pages.py
+++ b/tests/dashboard/test_pages.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from dashboard.app import TitanDashboard
+
+
+def test_dashboard_pages_render() -> None:
+    client = TestClient(TitanDashboard().create_app())
+
+    for path in ["/", "/inquiry", "/models", "/knowledge", "/analysis"]:
+        response = client.get(path)
+
+        assert response.status_code == 200
+        assert "<html" in response.text

--- a/tests/gateway/test_http_gateway.py
+++ b/tests/gateway/test_http_gateway.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import pytest
+
+from gateway import http_gateway
+
+
+def test_task_result_serializes_public_aliases() -> None:
+    result = http_gateway.TaskResult(
+        taskId="task-1",
+        status="completed",
+        result="done",
+        model="test-model",
+        agentType="researcher",
+    )
+
+    assert result.model_dump(by_alias=True) == {
+        "taskId": "task-1",
+        "status": "completed",
+        "result": "done",
+        "model": "test-model",
+        "agentType": "researcher",
+    }
+
+
+@pytest.mark.asyncio
+async def test_call_tool_uses_mcp_json_rpc(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured = {}
+
+    class FakeResponse:
+        error = None
+        result = {"content": [{"type": "text", "text": "ok"}]}
+
+    class FakeServer:
+        async def handle_request(self, request):
+            captured["request"] = request
+            return FakeResponse()
+
+    monkeypatch.setattr(http_gateway, "_mcp_server", FakeServer())
+
+    result = await http_gateway._call_tool("route_cognitive_task", {"task_description": "x"})
+
+    assert result == {"content": [{"type": "text", "text": "ok"}]}
+    assert captured["request"].jsonrpc == "2.0"
+    assert captured["request"].method == "tools/call"
+    assert captured["request"].params == {
+        "name": "route_cognitive_task",
+        "arguments": {"task_description": "x"},
+    }
+
+
+@pytest.mark.asyncio
+async def test_read_resource_uses_topology_uri(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured = {}
+
+    class FakeResponse:
+        error = None
+        result = {"contents": [{"text": "{}"}]}
+
+    class FakeServer:
+        async def handle_request(self, request):
+            captured["request"] = request
+            return FakeResponse()
+
+    monkeypatch.setattr(http_gateway, "_mcp_server", FakeServer())
+
+    result = await http_gateway._read_resource("titan://topology/current")
+
+    assert result == {"contents": [{"text": "{}"}]}
+    assert captured["request"].jsonrpc == "2.0"
+    assert captured["request"].method == "resources/read"
+    assert captured["request"].params == {"uri": "titan://topology/current"}

--- a/tests/integration/test_safety_integration.py
+++ b/tests/integration/test_safety_integration.py
@@ -105,7 +105,7 @@ class TestFilterPipelineIntegration:
     @pytest.mark.asyncio
     async def test_credentials_redacted(self, pipeline):
         """Test that credentials are redacted."""
-        content = "Use this API key: AKIAIOSFODNN7EXAMPLE123456789"
+        content = "Use this API key: AKIAIOSFODNN7EXAMPLE123456789"  # allow-secret
         result = await pipeline.filter(content)
         # Should be sanitized or blocked
         if result.filtered_content:

--- a/tests/learning/test_local_trainer.py
+++ b/tests/learning/test_local_trainer.py
@@ -1,6 +1,5 @@
-import pytest
-from pathlib import Path
-from titan.learning.local_trainer import LocalTrainer, TrainingConfig, PatternType
+from titan.learning.local_trainer import LocalTrainer, TrainingConfig
+
 
 def test_pattern_extraction_naming(tmp_path):
     code_dir = tmp_path / 'src'
@@ -19,7 +18,7 @@ class MyPascalClass:
 
     trainer = LocalTrainer(config=TrainingConfig(source_dirs=[str(code_dir)]))
     result = trainer.train(code_dir)
-    
+
     profile = result.style_profile
     assert profile.function_case == 'snake_case'
     assert profile.class_case == 'PascalCase'
@@ -37,15 +36,15 @@ def typed_func(x: int, y: str) -> str:
 
     trainer = LocalTrainer(config=TrainingConfig(min_examples=1))
     result = trainer.train(code_dir)
-    
+
     patterns = result.style_profile.patterns
     pattern_names = [p.name for p in patterns]
-    
+
     assert 'list_comprehension' in pattern_names
     assert 'type_annotations' in pattern_names
 
 def test_style_adapter_adaptation():
-    from titan.learning.local_trainer import StyleProfile, StyleAdapter
+    from titan.learning.local_trainer import StyleAdapter, StyleProfile
     profile = StyleProfile(quote_style='single')
     adapter = StyleAdapter(profile)
     code = 'print("hello world")'
@@ -53,7 +52,7 @@ def test_style_adapter_adaptation():
     assert "'hello world'" in adapted
 
 def test_style_adapter_suggestions():
-    from titan.learning.local_trainer import StyleProfile, StyleAdapter
+    from titan.learning.local_trainer import StyleAdapter, StyleProfile
     profile = StyleProfile(function_case='camelCase')
     adapter = StyleAdapter(profile)
     bad_code = 'def snake_case_func(): pass'

--- a/tests/test_hive/test_conflict_detection.py
+++ b/tests/test_hive/test_conflict_detection.py
@@ -10,14 +10,12 @@ from __future__ import annotations
 
 import math
 from datetime import UTC, datetime, timedelta
-from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from hive.conflict import SEMANTIC_OPPOSITES, ConflictDetector, ConflictPair
+from hive.conflict import ConflictDetector, ConflictPair
 from hive.fission_fusion import FissionFusionManager, FissionFusionState
 from hive.stigmergy import PheromoneField, PheromoneTrace, TraceType
-
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/test_hive/test_convergence_experiment.py
+++ b/tests/test_hive/test_convergence_experiment.py
@@ -178,18 +178,10 @@ class TestConvergenceExperiment:
     # --- Basic sweep behavior ---
 
     async def test_deterministic(self):
-        """Same seed produces identical deterministic fields.
-
-        Criticality metrics (correlation_length, order_parameter,
-        criticality_score) may vary slightly between runs because
-        TopologicalNeighborhood uses datetime.now() for interaction
-        recency scoring. We verify exact equality on fields controlled
-        by the seeded RNG and approximate equality on computed metrics.
-        """
+        """Same seed produces identical deterministic fields."""
         r1 = await ConvergenceExperiment(n_range=[8, 16, 24], seed=42).run()
         r2 = await ConvergenceExperiment(n_range=[8, 16, 24], seed=42).run()
         for p1, p2 in zip(r1.sweep_points, r2.sweep_points):
-            # Seeded RNG fields: exact match
             assert p1.agent_count == p2.agent_count
             assert p1.emergence_detected == p2.emergence_detected
             assert p1.novelty_ratio == p2.novelty_ratio
@@ -198,13 +190,8 @@ class TestConvergenceExperiment:
             assert p1.above_threshold == p2.above_threshold
             assert p1.total_interactions == p2.total_interactions
             assert p1.functional_connectivity == p2.functional_connectivity
-            # Computed metrics: approximate match (recency-dependent)
-            assert p1.correlation_length == pytest.approx(
-                p2.correlation_length, abs=0.02,
-            )
-            assert p1.order_parameter == pytest.approx(
-                p2.order_parameter, abs=0.02,
-            )
+            assert p1.correlation_length == p2.correlation_length
+            assert p1.order_parameter == p2.order_parameter
 
     async def test_different_seeds_differ(self):
         """Different seeds produce different vocabulary coverage."""

--- a/tests/test_hive/test_learning.py
+++ b/tests/test_hive/test_learning.py
@@ -1,6 +1,5 @@
 """Tests for hive episodic learning system."""
 
-import pytest
 
 from hive.learning import EpisodeOutcome
 
@@ -35,7 +34,10 @@ class TestEpisodeOutcome:
     def test_emergence_evidence_list(self):
         """emergence_evidence stores descriptions of novel information."""
         evidence = [
-            "Agents A+B deposited partial route data; collective output contained optimal route neither had",
+            (
+                "Agents A+B deposited partial route data; collective output "
+                "contained optimal route neither had"
+            ),
             "Synthesis produced a classification schema not present in any individual trace",
         ]
         outcome = self._make_outcome(

--- a/tests/test_hive/test_multi_scale_neighbors.py
+++ b/tests/test_hive/test_multi_scale_neighbors.py
@@ -114,18 +114,36 @@ class TestMultiScaleNeighborhood:
         # First call
         neighbors1 = neighborhood.get_neighbors("agent_0", layer=NeighborLayer.PRIMARY)
 
-        # Mark cache as valid
-        neighborhood._cache_valid = True
-
         # Second call should return same cached result
         neighbors2 = neighborhood.get_neighbors("agent_0", layer=NeighborLayer.PRIMARY)
 
         assert neighbors1 == neighbors2
 
+    def test_neighbor_cache_used_until_invalidated(self, neighborhood, monkeypatch):
+        """Cached neighbors are reused and cleared when topology inputs change."""
+        call_count = 0
+        original = neighborhood.calculate_neighbors
+
+        def counting_calculate(agent_id: str) -> list[str]:
+            nonlocal call_count
+            call_count += 1
+            return original(agent_id)
+
+        monkeypatch.setattr(neighborhood, "calculate_neighbors", counting_calculate)
+
+        neighborhood.get_neighbors("agent_0", layer=NeighborLayer.PRIMARY)
+        neighborhood.get_neighbors("agent_0", layer=NeighborLayer.PRIMARY)
+        assert call_count == 1
+
+        neighborhood.record_interaction(
+            "agent_0", "agent_4", InteractionType.COLLABORATION, True,
+        )
+        neighborhood.get_neighbors("agent_0", layer=NeighborLayer.PRIMARY)
+        assert call_count == 2
+
     def test_force_recalculate(self, neighborhood):
         """Test forcing recalculation bypasses cache."""
         neighborhood.get_neighbors("agent_0", layer=NeighborLayer.PRIMARY)
-        neighborhood._cache_valid = True
 
         # Force recalculate
         neighbors2 = neighborhood.get_neighbors(

--- a/tests/test_hive/test_perceptual_gating.py
+++ b/tests/test_hive/test_perceptual_gating.py
@@ -33,6 +33,22 @@ class TestSensingRegion:
         region = SensingRegion.full_field(min_intensity=0.5)
         assert region.min_intensity == 0.5
 
+    def test_restricted_with_invariant_types(self):
+        region = SensingRegion.restricted(
+            {"loc-a"},
+            trace_types={"path"},
+            invariant_types={"c:sync"},
+            transition_buffer=0.25,
+        )
+        assert region.allows_trace_type("path")
+        assert not region.allows_trace_type("resource")
+        assert region.is_invariant_type("collaboration", "c:sync")
+
+    def test_transition_buffer_advances(self):
+        region = SensingRegion.restricted({"loc-a"}, transition_buffer=0.5)
+        advanced = region.next_transition_buffer(step=0.3)
+        assert advanced.transition_buffer == pytest.approx(0.8)
+
     def test_frozen(self):
         region = SensingRegion.full_field()
         with pytest.raises(AttributeError):
@@ -169,6 +185,31 @@ class TestFissionFusionSensing:
         assert "a3" in region.locations
         assert "a1" not in region.locations
 
+    def test_transition_buffer_preserves_pre_fusion_boundary(self):
+        topo = FissionFusionTopology()
+        topo.add_agent("a1", "Agent 1", [], cluster_id="alpha")
+        topo.add_agent("a2", "Agent 2", [], cluster_id="alpha")
+        topo.add_agent("b1", "Agent B1", [], cluster_id="beta")
+
+        topo.fusion("beta", "alpha")
+
+        region = topo.get_sensing_region("a1")
+        assert region.locations == frozenset({"a1", "a2"})
+        assert region.transition_buffer == 0.0
+        assert "c:sync" in region.invariant_types
+
+    def test_transition_buffer_clears_after_full_pass(self):
+        topo = FissionFusionTopology(transition_buffer_step=0.6)
+        topo.add_agent("a1", "Agent 1", [], cluster_id="alpha")
+        topo.add_agent("b1", "Agent B1", [], cluster_id="beta")
+        topo.fusion("beta", "alpha")
+
+        assert topo.advance_transition_buffer() == pytest.approx(0.6)
+        assert topo.advance_transition_buffer() is None
+        region = topo.get_sensing_region("a1")
+        assert region.transition_buffer is None
+        assert region.locations == frozenset({"a1", "b1"})
+
 
 class TestStigmergicSensing:
     def test_full_field(self):
@@ -247,3 +288,69 @@ class TestPheromoneFieldFiltered:
         region = SensingRegion.restricted({"loc-z"})
         traces = await field.sense_filtered(region)
         assert traces == []
+
+    @pytest.mark.asyncio
+    async def test_invariant_type_bypasses_location_type_and_intensity(self):
+        field = PheromoneField()
+        await field.deposit("a1", TraceType.PATH, "loc-a", 0.9)
+        invariant = await field.deposit(
+            "b1",
+            TraceType.COLLABORATION,
+            "loc-b",
+            0.1,
+            payload={"atom_type": "c:sync"},
+        )
+
+        region = SensingRegion.restricted(
+            {"loc-a"},
+            min_intensity=0.5,
+            trace_types={"path"},
+            invariant_types={"c:sync"},
+        )
+        traces = await field.sense_filtered(region)
+
+        assert {trace.trace_id for trace in traces} == {"trace_default_1", invariant.trace_id}
+
+    @pytest.mark.asyncio
+    async def test_transition_buffer_attenuates_foreign_non_invariant_traces(self):
+        field = PheromoneField()
+        local = await field.deposit("a1", TraceType.PATH, "loc-a", 0.8)
+        foreign = await field.deposit(
+            "b1",
+            TraceType.RESOURCE,
+            "loc-b",
+            0.8,
+            payload={"atom_type": "o:agree"},
+        )
+        invariant = await field.deposit(
+            "b2",
+            TraceType.COLLABORATION,
+            "loc-b",
+            0.3,
+            payload={"atom_type": "c:sync"},
+        )
+
+        region = SensingRegion.restricted(
+            {"loc-a"},
+            invariant_types={"c:sync"},
+            transition_buffer=0.25,
+        )
+        traces = await field.sense_filtered(region)
+        by_id = {trace.trace_id: trace for trace in traces}
+
+        assert by_id[local.trace_id].intensity == pytest.approx(0.8)
+        assert by_id[foreign.trace_id].intensity == pytest.approx(0.2)
+        assert by_id[invariant.trace_id].intensity == pytest.approx(0.3)
+        assert foreign.intensity == pytest.approx(0.8)
+
+    @pytest.mark.asyncio
+    async def test_zero_transition_buffer_blocks_foreign_non_invariant_traces(self):
+        field = PheromoneField()
+        local = await field.deposit("a1", TraceType.PATH, "loc-a", 0.8)
+        foreign = await field.deposit("b1", TraceType.RESOURCE, "loc-b", 0.8)
+
+        region = SensingRegion.restricted({"loc-a"}, transition_buffer=0.0)
+        traces = await field.sense_filtered(region)
+
+        assert {trace.trace_id for trace in traces} == {local.trace_id}
+        assert foreign.trace_id not in {trace.trace_id for trace in traces}

--- a/titan/api/admin_routes.py
+++ b/titan/api/admin_routes.py
@@ -25,7 +25,7 @@ import logging
 import os
 import time
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, cast
 from uuid import uuid4
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
@@ -174,7 +174,8 @@ async def detailed_health() -> DetailedHealthResponse:
     try:
         import redis
 
-        r = redis.from_url(os.getenv("TITAN_REDIS_URL", "redis://localhost:6379"))
+        from_url = cast(Any, redis.from_url)
+        r = from_url(os.getenv("TITAN_REDIS_URL", "redis://localhost:6379"))
         r.ping()
         components["redis"] = {"status": "healthy", "connected": True}
     except Exception as e:
@@ -245,7 +246,8 @@ async def metrics_summary() -> MetricsSummaryResponse:
     try:
         import redis
 
-        r = redis.from_url(os.getenv("TITAN_REDIS_URL", "redis://localhost:6379"))
+        from_url = cast(Any, redis.from_url)
+        r = from_url(os.getenv("TITAN_REDIS_URL", "redis://localhost:6379"))
         redis_connected = bool(r.ping())
     except Exception:
         pass
@@ -665,7 +667,8 @@ async def flush_cache(
     try:
         import redis
 
-        r = redis.from_url(os.getenv("TITAN_REDIS_URL", "redis://localhost:6379"))
+        from_url = cast(Any, redis.from_url)
+        r = from_url(os.getenv("TITAN_REDIS_URL", "redis://localhost:6379"))
 
         keys_deleted: str | int
         if pattern == "*":
@@ -674,7 +677,7 @@ async def flush_cache(
             keys_deleted = "all"
         else:
             # Pattern-based deletion
-            matched_keys = list(r.keys(pattern))  # type: ignore[arg-type]
+            matched_keys = list(r.keys(pattern))
             if matched_keys:
                 r.delete(*matched_keys)
             keys_deleted = len(matched_keys)

--- a/titan/cli.py
+++ b/titan/cli.py
@@ -17,7 +17,7 @@ import asyncio
 import logging
 from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, cast
 
 import typer
 from rich.console import Console
@@ -33,6 +33,7 @@ from titan.spec import AgentSpec, get_spec_registry
 
 if TYPE_CHECKING:
     from adapters.router import LLMRouter
+    from agents.framework.base_agent import BaseAgent
 
 # Initialize
 app = typer.Typer(
@@ -97,8 +98,9 @@ async def check_infrastructure() -> dict[str, bool]:
         try:
             import redis.asyncio as redis_lib
 
-            r = redis_lib.from_url("redis://localhost:6379")
-            await r.ping()  # type: ignore[misc]
+            from_url = cast(Any, redis_lib.from_url)
+            r = from_url("redis://localhost:6379")
+            await r.ping()
             checks["redis"] = True
             await r.close()
         except Exception:
@@ -326,6 +328,7 @@ def swarm(
             agent_name = f"{archetype_name}-{i + 1}"
 
             # Create agent with appropriate initialization
+            agent: BaseAgent
             if archetype_class == ResearcherAgent:
                 agent = archetype_class(
                     topic=task,
@@ -431,11 +434,17 @@ def swarm(
 
         for r in results:
             state_style = "green" if r.get("state") == "completed" else "red"
+            duration_ms = r.get("duration_ms")
+            duration_text = (
+                f"{float(duration_ms) / 1000:.1f}s"
+                if isinstance(duration_ms, int | float)
+                else "-"
+            )
             table.add_row(
-                r["agent"],
+                str(r["agent"]),
                 f"[{state_style}]{r.get('state', 'unknown')}[/{state_style}]",
                 str(r.get("turns", "-")),
-                f"{r.get('duration_ms', 0) / 1000:.1f}s" if r.get("duration_ms") else "-",
+                duration_text,
             )
 
         console.print(table)

--- a/titan/learning/local_trainer.py
+++ b/titan/learning/local_trainer.py
@@ -180,6 +180,20 @@ class PatternExtractor:
                 description="Uses list comprehensions", frequency=list_comp_count,
                 source_files=[str(filepath)]
             ))
+        try:
+            tree = ast.parse(content)
+            annotation_count = sum(
+                1 for node in ast.walk(tree)
+                if isinstance(node, ast.FunctionDef) and node.returns is not None
+            )
+            if annotation_count > 0:
+                patterns.append(CodingPattern(
+                    type=PatternType.TYPING, name="type_annotations",
+                    description="Uses type annotations on functions", frequency=annotation_count,
+                    source_files=[str(filepath)]
+                ))
+        except SyntaxError:
+            pass
         return patterns
 
     def _detect_case(self, name: str) -> str:
@@ -224,7 +238,7 @@ class LocalTrainer:
         source_path = Path(source_path)
         files_analyzed = 0
         for filepath in source_path.rglob("*.py"):
-            if "test" in str(filepath): continue
+            if "test" in filepath.name: continue
             self._extractor.analyze_file(filepath)
             files_analyzed += 1
         self._style_profile = self._extractor.get_style_profile(min_frequency=self.config.min_examples)

--- a/titan/learning/local_trainer.py
+++ b/titan/learning/local_trainer.py
@@ -13,10 +13,7 @@ Reference: vendor/agents/igor/ local learning patterns
 from __future__ import annotations
 
 import ast
-import hashlib
-import json
 import logging
-import re
 from collections import Counter
 from dataclasses import dataclass, field
 from enum import StrEnum
@@ -24,6 +21,7 @@ from pathlib import Path
 from typing import Any
 
 logger = logging.getLogger("titan.learning.local_trainer")
+
 
 class PatternType(StrEnum):
     NAMING = "naming"
@@ -34,6 +32,7 @@ class PatternType(StrEnum):
     DOCSTRING = "docstring"
     ERROR_HANDLING = "error_handling"
     TYPING = "typing"
+
 
 @dataclass
 class CodingPattern:
@@ -56,6 +55,7 @@ class CodingPattern:
             "confidence": self.confidence,
             "language": self.language,
         }
+
 
 @dataclass
 class StyleProfile:
@@ -97,26 +97,31 @@ class StyleProfile:
 
     def to_prompt_context(self) -> str:
         lines = ["# Coding Style Guide", ""]
-        lines.extend([
-            "## Naming Conventions",
-            f"- Variables: {self.variable_case}",
-            f"- Functions: {self.function_case}",
-            f"- Classes: {self.class_case}",
-            f"- Constants: {self.constant_case}",
-            f"- Private members: prefix with '{self.private_prefix}'",
-            ""
-        ])
+        lines.extend(
+            [
+                "## Naming Conventions",
+                f"- Variables: {self.variable_case}",
+                f"- Functions: {self.function_case}",
+                f"- Classes: {self.class_case}",
+                f"- Constants: {self.constant_case}",
+                f"- Private members: prefix with '{self.private_prefix}'",
+                "",
+            ]
+        )
         if self.patterns:
             lines.extend(["## Common Patterns", ""])
             for pattern in self.patterns[:10]:
                 lines.append(f"- {pattern.name}: {pattern.description}")
         return "\n".join(lines)
 
+
 @dataclass
 class TrainingConfig:
     source_dirs: list[str] = field(default_factory=list)
     include_patterns: list[str] = field(default_factory=lambda: ["*.py"])
-    exclude_patterns: list[str] = field(default_factory=lambda: ["*test*", "*__pycache__*", "*.pyc"])
+    exclude_patterns: list[str] = field(
+        default_factory=lambda: ["*test*", "*__pycache__*", "*.pyc"]
+    )
     min_file_size: int = 100
     max_file_size: int = 1_000_000
     min_examples: int = 3
@@ -127,6 +132,7 @@ class TrainingConfig:
 
     def to_dict(self) -> dict[str, Any]:
         return {"min_examples": self.min_examples}
+
 
 @dataclass
 class TrainingResult:
@@ -143,6 +149,7 @@ class TrainingResult:
             "style_profile": self.style_profile.to_dict(),
         }
 
+
 class PatternExtractor:
     def __init__(self) -> None:
         self._naming_stats: Counter[str] = Counter()
@@ -153,7 +160,7 @@ class PatternExtractor:
             content = filepath.read_text(encoding="utf-8")
             tree = ast.parse(content)
             naming = self._extract_naming_patterns(tree, filepath)
-            idioms = self._extract_idiom_patterns(content, filepath)
+            idioms = self._extract_idiom_patterns(tree, filepath)
             file_patterns = naming + idioms
             self._patterns.extend(file_patterns)
             return file_patterns
@@ -171,48 +178,91 @@ class PatternExtractor:
                 self._naming_stats[f"class:{case}"] += 1
         return []
 
-    def _extract_idiom_patterns(self, content: str, filepath: Path) -> list[CodingPattern]:
+    def _extract_idiom_patterns(self, tree: ast.AST, filepath: Path) -> list[CodingPattern]:
         patterns = []
-        list_comp_count = len(re.findall(r"\[.+\s+for\s+.+\s+in\s+.+\]", content))
+        nodes = list(ast.walk(tree))
+        list_comp_count = sum(1 for node in nodes if isinstance(node, ast.ListComp))
         if list_comp_count > 0:
-            patterns.append(CodingPattern(
-                type=PatternType.IDIOM, name="list_comprehension",
-                description="Uses list comprehensions", frequency=list_comp_count,
-                source_files=[str(filepath)]
-            ))
+            patterns.append(
+                CodingPattern(
+                    type=PatternType.IDIOM,
+                    name="list_comprehension",
+                    description="Uses list comprehensions",
+                    frequency=list_comp_count,
+                    source_files=[str(filepath)],
+                )
+            )
+        annotated_functions = [
+            node
+            for node in nodes
+            if isinstance(node, ast.FunctionDef)
+            and (
+                node.returns is not None
+                or any(arg.annotation is not None for arg in node.args.args)
+                or any(arg.annotation is not None for arg in node.args.kwonlyargs)
+            )
+        ]
+        if annotated_functions:
+            patterns.append(
+                CodingPattern(
+                    type=PatternType.TYPING,
+                    name="type_annotations",
+                    description="Uses function type annotations",
+                    frequency=len(annotated_functions),
+                    source_files=[str(filepath)],
+                )
+            )
         return patterns
 
     def _detect_case(self, name: str) -> str:
-        if name.isupper(): return "UPPER_SNAKE_CASE"
-        if "_" in name: return "snake_case"
-        if name[0].isupper(): return "PascalCase"
+        if name.isupper():
+            return "UPPER_SNAKE_CASE"
+        if "_" in name:
+            return "snake_case"
+        if name[0].isupper():
+            return "PascalCase"
         return "snake_case"
 
     def get_style_profile(self, min_frequency: int = 3) -> StyleProfile:
         profile = StyleProfile()
         for prefix in ["function", "class"]:
-            cases = {k.split(":")[1]: v for k, v in self._naming_stats.items() if k.startswith(f"{prefix}:")}
+            cases = {
+                k.split(":")[1]: v
+                for k, v in self._naming_stats.items()
+                if k.startswith(f"{prefix}:")
+            }
             if cases:
-                setattr(profile, f"{prefix}_case", max(cases, key=cases.get))
-        
+                setattr(profile, f"{prefix}_case", max(cases, key=lambda case: cases[case]))
+
         profile.patterns = [p for p in self._patterns if p.frequency >= min_frequency]
         return profile
+
 
 class StyleAdapter:
     def __init__(self, style_profile: StyleProfile) -> None:
         self.style_profile = style_profile
+
     def adapt_code(self, code: str) -> str:
         if self.style_profile.quote_style == "single":
             return code.replace('"', "'")
         return code
+
     def suggest_improvements(self, code: str) -> list[str]:
         suggestions = []
         if "def " in code and self.style_profile.function_case == "camelCase" and "_" in code:
-            suggestions.append(f"Function uses snake_case, but project style is camelCase")
+            suggestions.append("Function uses snake_case, but project style is camelCase")
         return suggestions
 
+    def get_prompt_context(self) -> str:
+        return self.style_profile.to_prompt_context()
+
+
 class LocalTrainer:
-    def __init__(self, config: TrainingConfig | None = None, cache_dir: str | Path | None = None) -> None:
+    def __init__(
+        self,
+        config: TrainingConfig | None = None,
+        cache_dir: str | Path | None = None,
+    ) -> None:
         self.config = config or TrainingConfig()
         self.cache_dir = Path(cache_dir) if cache_dir else None
         self._style_profile: StyleProfile | None = None
@@ -224,30 +274,52 @@ class LocalTrainer:
         source_path = Path(source_path)
         files_analyzed = 0
         for filepath in source_path.rglob("*.py"):
-            if "test" in str(filepath): continue
+            if "test" in filepath.name:
+                continue
             self._extractor.analyze_file(filepath)
             files_analyzed += 1
-        self._style_profile = self._extractor.get_style_profile(min_frequency=self.config.min_examples)
+        self._style_profile = self._extractor.get_style_profile(
+            min_frequency=self.config.min_examples
+        )
         return TrainingResult(
             style_profile=self._style_profile,
             files_analyzed=files_analyzed,
             patterns_found=len(self._style_profile.patterns),
-            training_time_ms=(time.time() - start_time) * 1000
+            training_time_ms=(time.time() - start_time) * 1000,
         )
 
     def get_adapter(self) -> StyleAdapter:
         return StyleAdapter(self._style_profile or StyleProfile())
 
-def extract_patterns(source_path: str | Path, config: TrainingConfig | None = None) -> list[CodingPattern]:
+
+def extract_patterns(
+    source_path: str | Path,
+    config: TrainingConfig | None = None,
+) -> list[CodingPattern]:
     trainer = LocalTrainer(config=config)
     result = trainer.train(source_path)
     return result.style_profile.patterns
 
-def train_on_codebase(source_path: str | Path, config: TrainingConfig | None = None) -> TrainingResult:
+
+def train_on_codebase(
+    source_path: str | Path,
+    config: TrainingConfig | None = None,
+) -> TrainingResult:
     trainer = LocalTrainer(config=config)
     return trainer.train(source_path)
+
 
 def get_style_context(source_path: str | Path) -> str:
     trainer = LocalTrainer()
     trainer.train(source_path)
     return trainer.get_adapter().get_prompt_context()
+
+
+_trainer: LocalTrainer | None = None
+
+
+def get_trainer() -> LocalTrainer:
+    global _trainer
+    if _trainer is None:
+        _trainer = LocalTrainer()
+    return _trainer

--- a/titan/learning/local_trainer.py
+++ b/titan/learning/local_trainer.py
@@ -13,10 +13,7 @@ Reference: vendor/agents/igor/ local learning patterns
 from __future__ import annotations
 
 import ast
-import hashlib
-import json
 import logging
-import re
 from collections import Counter
 from dataclasses import dataclass, field
 from enum import StrEnum
@@ -24,6 +21,7 @@ from pathlib import Path
 from typing import Any
 
 logger = logging.getLogger("titan.learning.local_trainer")
+
 
 class PatternType(StrEnum):
     NAMING = "naming"
@@ -34,6 +32,7 @@ class PatternType(StrEnum):
     DOCSTRING = "docstring"
     ERROR_HANDLING = "error_handling"
     TYPING = "typing"
+
 
 @dataclass
 class CodingPattern:
@@ -56,6 +55,7 @@ class CodingPattern:
             "confidence": self.confidence,
             "language": self.language,
         }
+
 
 @dataclass
 class StyleProfile:
@@ -97,26 +97,31 @@ class StyleProfile:
 
     def to_prompt_context(self) -> str:
         lines = ["# Coding Style Guide", ""]
-        lines.extend([
-            "## Naming Conventions",
-            f"- Variables: {self.variable_case}",
-            f"- Functions: {self.function_case}",
-            f"- Classes: {self.class_case}",
-            f"- Constants: {self.constant_case}",
-            f"- Private members: prefix with '{self.private_prefix}'",
-            ""
-        ])
+        lines.extend(
+            [
+                "## Naming Conventions",
+                f"- Variables: {self.variable_case}",
+                f"- Functions: {self.function_case}",
+                f"- Classes: {self.class_case}",
+                f"- Constants: {self.constant_case}",
+                f"- Private members: prefix with '{self.private_prefix}'",
+                "",
+            ]
+        )
         if self.patterns:
             lines.extend(["## Common Patterns", ""])
             for pattern in self.patterns[:10]:
                 lines.append(f"- {pattern.name}: {pattern.description}")
         return "\n".join(lines)
 
+
 @dataclass
 class TrainingConfig:
     source_dirs: list[str] = field(default_factory=list)
     include_patterns: list[str] = field(default_factory=lambda: ["*.py"])
-    exclude_patterns: list[str] = field(default_factory=lambda: ["*test*", "*__pycache__*", "*.pyc"])
+    exclude_patterns: list[str] = field(
+        default_factory=lambda: ["*test*", "*__pycache__*", "*.pyc"]
+    )
     min_file_size: int = 100
     max_file_size: int = 1_000_000
     min_examples: int = 3
@@ -127,6 +132,7 @@ class TrainingConfig:
 
     def to_dict(self) -> dict[str, Any]:
         return {"min_examples": self.min_examples}
+
 
 @dataclass
 class TrainingResult:
@@ -143,6 +149,7 @@ class TrainingResult:
             "style_profile": self.style_profile.to_dict(),
         }
 
+
 class PatternExtractor:
     def __init__(self) -> None:
         self._naming_stats: Counter[str] = Counter()
@@ -153,7 +160,7 @@ class PatternExtractor:
             content = filepath.read_text(encoding="utf-8")
             tree = ast.parse(content)
             naming = self._extract_naming_patterns(tree, filepath)
-            idioms = self._extract_idiom_patterns(content, filepath)
+            idioms = self._extract_idiom_patterns(tree, filepath)
             file_patterns = naming + idioms
             self._patterns.extend(file_patterns)
             return file_patterns
@@ -171,62 +178,91 @@ class PatternExtractor:
                 self._naming_stats[f"class:{case}"] += 1
         return []
 
-    def _extract_idiom_patterns(self, content: str, filepath: Path) -> list[CodingPattern]:
+    def _extract_idiom_patterns(self, tree: ast.AST, filepath: Path) -> list[CodingPattern]:
         patterns = []
-        list_comp_count = len(re.findall(r"\[.+\s+for\s+.+\s+in\s+.+\]", content))
+        nodes = list(ast.walk(tree))
+        list_comp_count = sum(1 for node in nodes if isinstance(node, ast.ListComp))
         if list_comp_count > 0:
-            patterns.append(CodingPattern(
-                type=PatternType.IDIOM, name="list_comprehension",
-                description="Uses list comprehensions", frequency=list_comp_count,
-                source_files=[str(filepath)]
-            ))
-        try:
-            tree = ast.parse(content)
-            annotation_count = sum(
-                1 for node in ast.walk(tree)
-                if isinstance(node, ast.FunctionDef) and node.returns is not None
+            patterns.append(
+                CodingPattern(
+                    type=PatternType.IDIOM,
+                    name="list_comprehension",
+                    description="Uses list comprehensions",
+                    frequency=list_comp_count,
+                    source_files=[str(filepath)],
+                )
             )
-            if annotation_count > 0:
-                patterns.append(CodingPattern(
-                    type=PatternType.TYPING, name="type_annotations",
-                    description="Uses type annotations on functions", frequency=annotation_count,
-                    source_files=[str(filepath)]
-                ))
-        except SyntaxError:
-            pass
+        annotated_functions = [
+            node
+            for node in nodes
+            if isinstance(node, ast.FunctionDef)
+            and (
+                node.returns is not None
+                or any(arg.annotation is not None for arg in node.args.args)
+                or any(arg.annotation is not None for arg in node.args.kwonlyargs)
+            )
+        ]
+        if annotated_functions:
+            patterns.append(
+                CodingPattern(
+                    type=PatternType.TYPING,
+                    name="type_annotations",
+                    description="Uses function type annotations",
+                    frequency=len(annotated_functions),
+                    source_files=[str(filepath)],
+                )
+            )
         return patterns
 
     def _detect_case(self, name: str) -> str:
-        if name.isupper(): return "UPPER_SNAKE_CASE"
-        if "_" in name: return "snake_case"
-        if name[0].isupper(): return "PascalCase"
+        if name.isupper():
+            return "UPPER_SNAKE_CASE"
+        if "_" in name:
+            return "snake_case"
+        if name[0].isupper():
+            return "PascalCase"
         return "snake_case"
 
     def get_style_profile(self, min_frequency: int = 3) -> StyleProfile:
         profile = StyleProfile()
         for prefix in ["function", "class"]:
-            cases = {k.split(":")[1]: v for k, v in self._naming_stats.items() if k.startswith(f"{prefix}:")}
+            cases = {
+                k.split(":")[1]: v
+                for k, v in self._naming_stats.items()
+                if k.startswith(f"{prefix}:")
+            }
             if cases:
-                setattr(profile, f"{prefix}_case", max(cases, key=cases.get))
-        
+                setattr(profile, f"{prefix}_case", max(cases, key=lambda case: cases[case]))
+
         profile.patterns = [p for p in self._patterns if p.frequency >= min_frequency]
         return profile
+
 
 class StyleAdapter:
     def __init__(self, style_profile: StyleProfile) -> None:
         self.style_profile = style_profile
+
     def adapt_code(self, code: str) -> str:
         if self.style_profile.quote_style == "single":
             return code.replace('"', "'")
         return code
+
     def suggest_improvements(self, code: str) -> list[str]:
         suggestions = []
         if "def " in code and self.style_profile.function_case == "camelCase" and "_" in code:
-            suggestions.append(f"Function uses snake_case, but project style is camelCase")
+            suggestions.append("Function uses snake_case, but project style is camelCase")
         return suggestions
 
+    def get_prompt_context(self) -> str:
+        return self.style_profile.to_prompt_context()
+
+
 class LocalTrainer:
-    def __init__(self, config: TrainingConfig | None = None, cache_dir: str | Path | None = None) -> None:
+    def __init__(
+        self,
+        config: TrainingConfig | None = None,
+        cache_dir: str | Path | None = None,
+    ) -> None:
         self.config = config or TrainingConfig()
         self.cache_dir = Path(cache_dir) if cache_dir else None
         self._style_profile: StyleProfile | None = None
@@ -238,30 +274,52 @@ class LocalTrainer:
         source_path = Path(source_path)
         files_analyzed = 0
         for filepath in source_path.rglob("*.py"):
-            if "test" in filepath.name: continue
+            if "test" in filepath.name:
+                continue
             self._extractor.analyze_file(filepath)
             files_analyzed += 1
-        self._style_profile = self._extractor.get_style_profile(min_frequency=self.config.min_examples)
+        self._style_profile = self._extractor.get_style_profile(
+            min_frequency=self.config.min_examples
+        )
         return TrainingResult(
             style_profile=self._style_profile,
             files_analyzed=files_analyzed,
             patterns_found=len(self._style_profile.patterns),
-            training_time_ms=(time.time() - start_time) * 1000
+            training_time_ms=(time.time() - start_time) * 1000,
         )
 
     def get_adapter(self) -> StyleAdapter:
         return StyleAdapter(self._style_profile or StyleProfile())
 
-def extract_patterns(source_path: str | Path, config: TrainingConfig | None = None) -> list[CodingPattern]:
+
+def extract_patterns(
+    source_path: str | Path,
+    config: TrainingConfig | None = None,
+) -> list[CodingPattern]:
     trainer = LocalTrainer(config=config)
     result = trainer.train(source_path)
     return result.style_profile.patterns
 
-def train_on_codebase(source_path: str | Path, config: TrainingConfig | None = None) -> TrainingResult:
+
+def train_on_codebase(
+    source_path: str | Path,
+    config: TrainingConfig | None = None,
+) -> TrainingResult:
     trainer = LocalTrainer(config=config)
     return trainer.train(source_path)
+
 
 def get_style_context(source_path: str | Path) -> str:
     trainer = LocalTrainer()
     trainer.train(source_path)
     return trainer.get_adapter().get_prompt_context()
+
+
+_trainer: LocalTrainer | None = None
+
+
+def get_trainer() -> LocalTrainer:
+    global _trainer
+    if _trainer is None:
+        _trainer = LocalTrainer()
+    return _trainer

--- a/titan/orchestration/dialectic_swarm.py
+++ b/titan/orchestration/dialectic_swarm.py
@@ -1,40 +1,42 @@
 """
 Titan Orchestration - Dialectic Swarm
 
-Orchestrates a triadic agent swarm (Thesis, Antithesis, Synthesis) 
+Orchestrates a triadic agent swarm (Thesis, Antithesis, Synthesis)
 to resolve complex system problems with high-fidelity reasoning.
 """
 
 from __future__ import annotations
 
-import asyncio
 import logging
 from dataclasses import dataclass, field
-from typing import Any, List, Optional
+from typing import Any
 
-from titan.analysis.dialectic import DialecticSynthesizer, SynthesisResult, SynthesisStrategy
 from titan.analysis.contradictions import Contradiction, ContradictionType
+from titan.analysis.dialectic import DialecticSynthesizer, SynthesisResult
 from titan.learning.local_trainer import get_trainer
 
 logger = logging.getLogger("titan.orchestration.dialectic_swarm")
 
+
 @dataclass
 class SwarmTurn:
     """A single turn in the dialectic dialogue."""
+
     role: str
     content: str
     metadata: dict[str, Any] = field(default_factory=dict)
 
+
 class DialecticSwarm:
     """
     Triadic Swarm Orchestrator.
-    
+
     Roles:
     - Thesis: Proposes a solution
     - Antithesis: Identifies flaws and counter-perspectives
     - Synthesis: Resolves the conflict into a verified plan
     """
-    
+
     def __init__(self, llm_caller: Any):
         self.llm_caller = llm_caller
         self.synthesizer = DialecticSynthesizer(llm_caller=llm_caller)
@@ -43,13 +45,13 @@ class DialecticSwarm:
     async def resolve(self, problem_description: str) -> SynthesisResult:
         """Execute the triadic swarm loop to resolve a problem."""
         logger.info(f"Swarm activated for problem: {problem_description[:50]}...")
-        
+
         # 1. THESIS: Generate proposal
         thesis_content = await self._spawn_thesis(problem_description)
-        
+
         # 2. ANTITHESIS: Challenge the proposal
         antithesis_content = await self._spawn_antithesis(problem_description, thesis_content)
-        
+
         # 3. CONTRADICTION EXTRACTION
         contradiction = Contradiction(
             source_a="ThesisAgent",
@@ -57,19 +59,23 @@ class DialecticSwarm:
             source_b="AntithesisAgent",
             content_b=antithesis_content,
             explanation=f"Conflict regarding: {problem_description}",
-            contradiction_type=ContradictionType.LOGICAL
+            contradiction_type=ContradictionType.LOGICAL,
         )
-        
+
         # 4. SYNTHESIS: Generate the final plan
         result = await self.synthesizer.synthesize_contradiction(contradiction)
-        
+
         # 5. STYLE ADAPTATION
         style_context = self.trainer.get_adapter().get_prompt_context()
-        final_prompt = f"Given this synthesized solution:\n{result.synthesis}\n\nAdapt it to this style guide:\n{style_context}\n\nProduce the FINAL EXECUTABLE PLAN."
-        
+        final_prompt = (
+            f"Given this synthesized solution:\n{result.synthesis}\n\n"
+            f"Adapt it to this style guide:\n{style_context}\n\n"
+            "Produce the FINAL EXECUTABLE PLAN."
+        )
+
         final_plan = await self.llm_caller(final_prompt, "titan-synthesis")
         result.synthesis = final_plan if isinstance(final_plan, str) else str(final_plan)
-        
+
         return result
 
     async def _spawn_thesis(self, problem: str) -> str:
@@ -78,6 +84,9 @@ class DialecticSwarm:
         return resp if isinstance(resp, str) else str(resp)
 
     async def _spawn_antithesis(self, problem: str, thesis: str) -> str:
-        prompt = f"Role: ADVERSARY. Task: Find critical flaws, security risks, and edge cases in this proposal:\n{thesis}\n\nContext: {problem}"
+        prompt = (
+            "Role: ADVERSARY. Task: Find critical flaws, security risks, "
+            f"and edge cases in this proposal:\n{thesis}\n\nContext: {problem}"
+        )
         resp = await self.llm_caller(prompt, "titan-antithesis")
         return resp if isinstance(resp, str) else str(resp)

--- a/titan/safety/hitl.py
+++ b/titan/safety/hitl.py
@@ -10,7 +10,7 @@ import json
 import logging
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 from uuid import UUID
 
 from titan.safety.gates import (
@@ -92,7 +92,8 @@ class HITLHandler:
             try:
                 import redis.asyncio as redis
 
-                self._redis = await redis.from_url(self.config.redis_url)
+                from_url = cast(Any, redis.from_url)
+                self._redis = await from_url(self.config.redis_url)
                 logger.info("HITL connected to Redis for distributed state")
             except Exception as e:
                 logger.warning(f"Failed to connect to Redis: {e}")

--- a/titan/stress/scenarios.py
+++ b/titan/stress/scenarios.py
@@ -400,4 +400,7 @@ def get_scenario(name: str, **kwargs: Any) -> Scenario:
 
 def list_scenarios() -> list[dict[str, str]]:
     """List available scenarios."""
-    return [{"name": name, "description": cls.description} for name, cls in SCENARIOS.items()]
+    return [
+        {"name": name, "description": cast(Any, cls).description}
+        for name, cls in SCENARIOS.items()
+    ]


### PR DESCRIPTION
## Summary
- Preserve the original local trainer fix from PR #80: filename-only test exclusion plus `type_annotations` pattern extraction.
- Fold in the frontend/backend technical-debt cleanup from PR #83: gateway MCP dispatch, dashboard rendering hardening, strict Ruff/mypy cleanup, neighborhood cache behavior, and regression tests.
- Add invariant perceptual-gating support so coordination atoms such as `c:sync`, `c:ack`, `c:yield`, and `c:delegate` bypass topology/type gates.
- Add fission-fusion transition buffering so non-invariant foreign traces are blocked or attenuated during merge windows while invariant traces pass through at full strength.
- Remove wall-clock recency from the synthetic convergence experiment so same-seed runs are deterministic under full coverage.

## GitHub Backlog
- Fixes #81.
- Fixes #82.
- Supersedes #83; its commit is now included in this branch.

## Verification
- `uv run --python 3.11 --with '.[dev,dashboard,auth,ratelimit]' ruff check .` -> All checks passed.
- `uv run --python 3.11 --with '.[dev,dashboard,auth,ratelimit]' mypy .` -> Success: no issues found in 221 source files.
- `uv run --python 3.11 --with '.[dev,dashboard,auth,ratelimit]' pytest tests/test_hive/test_perceptual_gating.py` -> 30 passed.
- `uv run --python 3.11 --with '.[dev,dashboard,auth,ratelimit]' pytest tests/test_hive/test_convergence_experiment.py` -> 34 passed.
- `uv run --python 3.11 --with '.[dev,dashboard,auth,ratelimit]' pytest --cov=. --cov-report=xml --cov-report=term --cov-report=html` -> 1556 passed, 18 skipped, 1 warning.

## Notes
- The remaining warning is the existing Starlette/FastAPI `httpx` deprecation warning from `fastapi.testclient`.
