### PR TITLE
Add contributor and logos documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,8 @@ pip install -e ".[dev]"
 
 For optional extras (dashboard, metrics, vector-db, etc.), see `pyproject.toml`.
 
+For a fuller first-run workflow, see [docs/getting-started.md](docs/getting-started.md).
+
 ## Tests
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 > A polymorphic, model-agnostic multi-agent orchestration framework with nine topology patterns, 22 agent archetypes, and production-grade safety infrastructure — from two agents on a laptop to 100+ agents across Firecracker microVMs.
 
-[Problem Statement](#problem-statement) | [Core Architecture](#core-architecture) | [Key Concepts](#key-concepts) | [Installation & Setup](#installation--setup) | [Quick Start](#quick-start) | [Working Examples](#working-examples) | [Testing & Validation](#testing--validation) | [Downstream Implementation](#downstream-implementation) | [Cross-References](#cross-references) | [Contributing](#contributing) | [License & Author](#license--author)
+[Problem Statement](#problem-statement) | [Core Architecture](#core-architecture) | [Key Concepts](#key-concepts) | [Installation & Setup](#installation--setup) | [Quick Start](#quick-start) | [Working Examples](#working-examples) | [Testing & Validation](#testing--validation) | [Getting Started](docs/getting-started.md) | [Downstream Implementation](#downstream-implementation) | [Cross-References](#cross-references) | [Contributing](#contributing) | [License & Author](#license--author)
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,76 @@
+# Getting Started
+
+This guide is the short path from a fresh checkout to a useful local
+development loop for Agentic Titan.
+
+## 1. Prepare Python
+
+Use Python 3.11 or newer. The CI matrix covers Python 3.11 and 3.12.
+
+```bash
+python3.11 -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip
+pip install -e ".[dev,dashboard,auth,ratelimit]"
+```
+
+If you use `uv`, the equivalent local command is:
+
+```bash
+uv run --python 3.11 --with '.[dev,dashboard,auth,ratelimit]' pytest
+```
+
+## 2. Run The Quality Loop
+
+Run these before opening a pull request:
+
+```bash
+ruff check .
+mypy .
+pytest
+```
+
+For the same coverage mode used in CI:
+
+```bash
+pytest --cov=. --cov-report=xml --cov-report=term --cov-report=html
+```
+
+## 3. Work In The Right Layer
+
+The repo is organized as root-level Python packages:
+
+| Path | Purpose |
+| --- | --- |
+| `titan/` | CLI, API, orchestration, safety, learning, and workflow code. |
+| `hive/` | Collective behavior primitives: memory, topology, stigmergy, and experiments. |
+| `agents/` | Agent archetypes and reusable agent behaviors. |
+| `adapters/` | LLM provider adapters and routing. |
+| `runtime/` | Local and isolated execution backends. |
+| `dashboard/` | FastAPI dashboard and templates. |
+| `.ci/` | Local governance and quality scripts used by CI. |
+
+## 4. Choose The Smallest Verification Set First
+
+For a narrow fix, start with the relevant test file:
+
+```bash
+pytest tests/test_hive/test_perceptual_gating.py
+pytest tests/ci/test_ai_quality_gate.py
+```
+
+Then run the broader gates before pushing:
+
+```bash
+ruff check .
+mypy .
+pytest --cov=. --cov-report=xml --cov-report=term --cov-report=html
+```
+
+## 5. Respect The Governance Boundary
+
+This repo participates in ORGAN-IV orchestration. Keep dependencies flowing in
+the approved direction, do not commit secrets, and do not bypass the
+branch-protection dependency validation status. If a pull request is blocked on
+`validate-dependencies`, run the canonical dependency validator and publish a
+status only after it passes.

--- a/docs/logos/alchemical-io.md
+++ b/docs/logos/alchemical-io.md
@@ -1,0 +1,26 @@
+# Alchemical I/O
+
+Alchemical I/O records the repository's transformation pattern: what enters the
+system, how it is processed, and what returns to the broader ORGANVM graph.
+
+## Inputs
+
+- User tasks and agent specifications.
+- Provider responses from local and cloud LLM adapters.
+- Shared-memory traces, topology metrics, and dashboard events.
+- Governance constraints from the dependency graph and branch protection.
+
+## Transmutation
+
+Inputs pass through routing, topology selection, safety checks, and workflow
+execution. The system should preserve enough evidence to audit each transition:
+which agent acted, which model or runtime was selected, which gate approved or
+blocked action, and which tests protect the behavior.
+
+## Outputs
+
+- Agent results and workflow artifacts.
+- Metrics, audit logs, and dashboard-visible state.
+- Dependency-compatible code and documentation changes.
+- Public process material when changes need a narrative record outside this
+  repository.

--- a/docs/logos/pragma.md
+++ b/docs/logos/pragma.md
@@ -1,0 +1,24 @@
+# Pragma
+
+Pragma records the concrete state of the repository.
+
+## Current Surface
+
+- Python package layout is root-based: `titan/`, `hive/`, `agents/`,
+  `adapters/`, `runtime/`, and `dashboard/`.
+- CI covers linting, strict type checking, tests with coverage, CodeQL, secret
+  pattern detection, release drafting, and an advisory AI quality gate.
+- The topology layer includes fission-fusion behavior, stigmergic traces,
+  perceptual gating, multi-scale neighborhoods, and convergence experiments.
+- The adapter layer supports provider routing across local and cloud model
+  backends.
+- The dashboard and gateway expose operational surfaces for inspection and
+  orchestration.
+
+## Known Boundaries
+
+- Long-horizon research issues remain open for topology concepts that do not
+  yet have an implementation path.
+- Local-inference sovereignty remains an R&D track, not a completed guarantee.
+- Cross-model replay/diff has a design document, but its CLI and persistence
+  implementation remain future work.

--- a/docs/logos/praxis.md
+++ b/docs/logos/praxis.md
@@ -1,0 +1,23 @@
+# Praxis
+
+Praxis records the active remediation path for keeping Agentic Titan coherent.
+
+## Maintenance Loop
+
+1. Keep `ruff check .`, `mypy .`, and the pytest suite green.
+2. Treat branch-protection dependency validation as a real governance gate.
+3. Keep generated reports and local coverage artifacts out of commits.
+4. Add tests beside behavior changes, especially in topology, safety, routing,
+   and dashboard surfaces.
+5. Prefer advisory reporting before turning new quality gates into blocking
+   gates.
+
+## Near-Term Work
+
+- Calibrate advisory AI quality findings into a reviewed baseline.
+- Continue reducing duplicate adapter/router code surfaced by the advisory
+  gate.
+- Keep topology-gating behavior covered as fission-fusion and stigmergic
+  coordination evolve.
+- Split large research ideas into implementation-ready issues only after their
+  contracts, tests, and success criteria are clear.

--- a/docs/logos/receptio.md
+++ b/docs/logos/receptio.md
@@ -1,0 +1,24 @@
+# Receptio
+
+Receptio records how Agentic Titan is received by its surrounding system.
+
+## Internal Reception
+
+Agentic Titan acts as an ORGAN-IV orchestration substrate. It is useful when it
+makes coordination choices explicit, measurable, and reversible. Its strongest
+internal value is not raw agent count, but the ability to explain why a
+formation, model route, or safety gate was selected.
+
+## Downstream Reception
+
+Downstream consumers need stable dependency behavior, clear public contracts,
+and proof that local changes do not violate the broader dependency graph. This
+is why pull requests require ordinary CI checks plus the `validate-dependencies`
+status.
+
+## Public Reception
+
+The public-facing account should present concrete evidence: merged changes,
+green checks, smoke results, and documented tradeoffs. Broad claims about
+autonomy or orchestration should remain tied to reproducible repository
+artifacts.

--- a/docs/logos/telos.md
+++ b/docs/logos/telos.md
@@ -1,0 +1,26 @@
+# Telos
+
+Telos records the idealized form of Agentic Titan: what the system is trying to
+be when its architecture is coherent.
+
+Agentic Titan exists to make multi-agent coordination adaptable, inspectable,
+and model-agnostic. Its ideal form is not a single fixed topology or a single
+provider wrapper. It is a runtime that can select, combine, and revise
+coordination patterns as work changes.
+
+## Ideal Commitments
+
+- Topology is a runtime decision, not a static framework choice.
+- Model providers are interchangeable execution substrates behind one adapter
+  contract.
+- Safety gates, auditability, and budget controls are part of the execution
+  path.
+- Coordination traces are evidence, not decorative telemetry.
+- Local development and production deployment should exercise the same public
+  contracts.
+
+## Architectural North Star
+
+The system should let a user describe work, route that work through appropriate
+agent formations, preserve the evidence of why decisions were made, and degrade
+cleanly when a model, runtime, or tool is unavailable.


### PR DESCRIPTION
## Summary

Closes the remaining documentation cleanup gaps from the repository cleanup epic by adding a practical contributor getting-started guide and the missing Logos documentation layer.

## Changes

- Add `docs/getting-started.md` with setup, quality-loop, package layout, and governance notes.
- Add `docs/logos/` pages for telos, pragma, praxis, receptio, and alchemical I/O.
- Link the getting-started guide from README and CONTRIBUTING.

## Related Issues

Fixes #37

## Testing

- [x] `git diff --check`
- [x] `git diff --cached --check`

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Documentation updated
- [x] No secrets or credentials included