### PR TITLE
Implement cross-model replay CLI

### DIFF
--- a/docs/cross-model-replay.md
+++ b/docs/cross-model-replay.md
@@ -2,6 +2,20 @@
 
 > Replay the same prompt across multiple models and diff outputs for consistency, bias detection, and quality comparison.
 
+## Implementation Status
+
+Implemented CLI surface:
+
+```bash
+titan replay capture --prompt "Review this code for security issues"
+titan replay run --id rec_... --targets anthropic:claude-sonnet-4-20250514,openai:gpt-4o
+titan replay diff --id rec_... --format markdown
+```
+
+Replay records and run results are stored as JSON under `.titan/replays/` by
+default. The diff command renders pairwise agreement, length ratio, shared
+terms, target errors, and side-by-side output previews.
+
 ## Use Cases
 
 | Use Case | Description |

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -1,0 +1,141 @@
+"""Tests for cross-model replay storage, dispatch, and diff."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from adapters.base import LLMMessage, LLMProvider, LLMResponse
+from titan.replay import (
+    ModelTarget,
+    ReplayError,
+    ReplayStore,
+    build_diff,
+    dispatch_replay,
+    parse_model_targets,
+    render_diff_markdown,
+)
+
+
+class FakeRouter:
+    """Deterministic replay router for tests."""
+
+    async def complete(
+        self,
+        messages: list[LLMMessage],
+        *,
+        system: str | None = None,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+        provider: LLMProvider | None = None,
+        model: str | None = None,
+    ) -> LLMResponse:
+        del system, temperature, max_tokens
+        assert provider is not None
+        prompt = messages[-1].content
+        return LLMResponse(
+            content=f"{provider.value} recommends input validation for {prompt[:20]}",
+            model=model or f"{provider.value}-default",
+            provider=provider.value,
+            usage={"total_tokens": 12},
+        )
+
+
+def test_parse_model_targets_supports_provider_and_model() -> None:
+    targets = parse_model_targets("anthropic:claude, openai/gpt-4o, ollama")
+
+    assert targets == [
+        ModelTarget(LLMProvider.ANTHROPIC, "claude"),
+        ModelTarget(LLMProvider.OPENAI, "gpt-4o"),
+        ModelTarget(LLMProvider.OLLAMA, None),
+    ]
+
+
+def test_parse_model_targets_rejects_unknown_provider() -> None:
+    with pytest.raises(ReplayError, match="Unknown provider"):
+        parse_model_targets("not-a-provider")
+
+
+@pytest.mark.asyncio
+async def test_replay_store_dispatch_and_diff(tmp_path: Path) -> None:
+    store = ReplayStore(tmp_path / "replays")
+    record = store.capture(
+        prompt="Review this function",
+        system="Be concise",
+        context="def add(a, b): return a + b",
+    )
+
+    run = await dispatch_replay(
+        record,
+        parse_model_targets("anthropic:claude-test,openai:gpt-test"),
+        FakeRouter(),
+        max_tokens=128,
+    )
+    store.save_run(run)
+
+    loaded_record = store.load_record(record.id)
+    loaded_run = store.load_run(record.id, run.id)
+    latest_run = store.latest_run(record.id)
+    diff = build_diff(loaded_run)
+    markdown = render_diff_markdown(loaded_run, diff)
+
+    assert loaded_record.context == "def add(a, b): return a + b"
+    assert latest_run.id == run.id
+    assert [output.target for output in loaded_run.outputs] == [
+        "anthropic:claude-test",
+        "openai:gpt-test",
+    ]
+    assert loaded_run.outputs[0].usage == {"total_tokens": 12}
+    assert diff["comparisons"][0]["left"] == "anthropic:claude-test"
+    assert diff["comparisons"][0]["right"] == "openai:gpt-test"
+    assert "Pairwise Comparisons" in markdown
+
+
+@pytest.mark.asyncio
+async def test_dispatch_requires_two_targets(tmp_path: Path) -> None:
+    store = ReplayStore(tmp_path / "replays")
+    record = store.capture(prompt="Hello")
+
+    with pytest.raises(ReplayError, match="at least two targets"):
+        await dispatch_replay(
+            record,
+            [ModelTarget(LLMProvider.OPENAI)],
+            FakeRouter(),
+        )
+
+
+class FailingRouter:
+    """Router that fails one target and succeeds another."""
+
+    async def complete(
+        self,
+        messages: list[LLMMessage],
+        **kwargs: Any,
+    ) -> LLMResponse:
+        del messages
+        provider = kwargs["provider"]
+        assert isinstance(provider, LLMProvider)
+        if provider == LLMProvider.OPENAI:
+            raise RuntimeError("provider unavailable")
+        return LLMResponse(content="local answer", model="llama", provider=provider.value)
+
+
+@pytest.mark.asyncio
+async def test_dispatch_stores_target_errors(tmp_path: Path) -> None:
+    store = ReplayStore(tmp_path / "replays")
+    record = store.capture(prompt="Hello")
+
+    run = await dispatch_replay(
+        record,
+        parse_model_targets("openai,ollama"),
+        FailingRouter(),
+    )
+
+    errors = [output for output in run.outputs if output.error]
+    assert len(errors) == 1
+    assert errors[0].target == "openai"
+    assert build_diff(run)["errors"] == [
+        {"target": "openai", "error": "provider unavailable"}
+    ]

--- a/titan/cli.py
+++ b/titan/cli.py
@@ -14,6 +14,7 @@ Inspired by: kimi-cli mode-switching patterns
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 from datetime import datetime
 from pathlib import Path
@@ -1345,6 +1346,148 @@ inquiry_app = typer.Typer(
     help="Multi-perspective inquiry commands",
 )
 app.add_typer(inquiry_app, name="inquiry")
+
+
+# ============================================================================
+# Replay Commands
+# ============================================================================
+
+replay_app = typer.Typer(
+    name="replay",
+    help="Capture prompts, replay them across model targets, and diff outputs",
+)
+app.add_typer(replay_app, name="replay")
+
+
+@replay_app.command("capture")
+def replay_capture(
+    prompt: str = typer.Option(..., "--prompt", "-p", help="Prompt to capture"),
+    system: str | None = typer.Option(None, "--system", "-s", help="Optional system prompt"),
+    context: Path | None = typer.Option(
+        None,
+        "--context",
+        "-c",
+        help="Optional context file to append during replay",
+    ),
+    store: Path = typer.Option(
+        Path(".titan/replays"),
+        "--store",
+        help="Replay storage directory",
+    ),
+) -> None:
+    """Capture a prompt for future cross-model replay."""
+    from titan.replay import ReplayStore
+
+    context_text = context.read_text(encoding="utf-8") if context else None
+    replay_store = ReplayStore(store)
+    record = replay_store.capture(prompt=prompt, system=system, context=context_text)
+    console.print(f"[green]Captured replay record[/green] `{record.id}`")
+    console.print(f"Path: {replay_store.record_path(record.id)}")
+
+
+@replay_app.command("run")
+def replay_run(
+    record_id: str = typer.Option(..., "--id", help="Replay record id"),
+    targets: str = typer.Option(
+        ...,
+        "--targets",
+        "-t",
+        help="Comma-separated providers or provider:model targets",
+    ),
+    store: Path = typer.Option(
+        Path(".titan/replays"),
+        "--store",
+        help="Replay storage directory",
+    ),
+    max_tokens: int = typer.Option(1024, "--max-tokens", help="Max output tokens per target"),
+    temperature: float | None = typer.Option(None, "--temperature", help="Sampling temperature"),
+) -> None:
+    """Replay a captured prompt across two or more model targets."""
+    from titan.replay import ReplayError, ReplayStore, dispatch_replay, parse_model_targets
+
+    try:
+        model_targets = parse_model_targets(targets)
+        if len(model_targets) < 2:
+            raise ReplayError("Use at least two targets, for example: anthropic,openai")
+        replay_store = ReplayStore(store)
+        record = replay_store.load_record(record_id)
+    except ReplayError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(1) from exc
+
+    async def run_replay() -> None:
+        router = get_router()
+        run = await dispatch_replay(
+            record,
+            model_targets,
+            router,
+            max_tokens=max_tokens,
+            temperature=temperature,
+        )
+        replay_store.save_run(run)
+
+        table = Table(title=f"Replay Run {run.id}")
+        table.add_column("Target")
+        table.add_column("Status")
+        table.add_column("Model")
+        table.add_column("Latency")
+        for output in run.outputs:
+            table.add_row(
+                output.target,
+                "error" if output.error else "ok",
+                output.model or "",
+                f"{output.latency_ms:.1f} ms",
+            )
+        console.print(table)
+        console.print(f"Saved: {replay_store.run_path(record.id, run.id)}")
+
+        if all(output.error for output in run.outputs):
+            raise typer.Exit(1)
+
+    asyncio.run(run_replay())
+
+
+@replay_app.command("diff")
+def replay_diff(
+    record_id: str = typer.Option(..., "--id", help="Replay record id"),
+    run_id: str | None = typer.Option(None, "--run-id", help="Replay run id; defaults latest"),
+    store: Path = typer.Option(
+        Path(".titan/replays"),
+        "--store",
+        help="Replay storage directory",
+    ),
+    output: Path | None = typer.Option(None, "--output", "-o", help="Optional report path"),
+    format: str = typer.Option("markdown", "--format", help="Output format: markdown, json"),
+) -> None:
+    """Render a structured diff for a stored replay run."""
+    from titan.replay import ReplayError, ReplayStore, build_diff, render_diff_markdown
+
+    try:
+        replay_store = ReplayStore(store)
+        run = (
+            replay_store.load_run(record_id, run_id)
+            if run_id
+            else replay_store.latest_run(record_id)
+        )
+        diff = build_diff(run)
+    except ReplayError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(1) from exc
+
+    if format == "json":
+        rendered = json.dumps(diff, indent=2, sort_keys=True) + "\n"
+    elif format == "markdown":
+        rendered = render_diff_markdown(run, diff)
+    else:
+        console.print("[red]Unknown format. Available: markdown, json[/red]")
+        raise typer.Exit(1)
+
+    if output:
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(rendered, encoding="utf-8")
+        console.print(f"Saved: {output}")
+    else:
+        console.print(rendered)
 
 
 @inquiry_app.command("start")

--- a/titan/replay.py
+++ b/titan/replay.py
@@ -1,0 +1,372 @@
+"""Cross-model prompt replay and diff utilities."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+import time
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Protocol, cast
+from uuid import uuid4
+
+from adapters.base import LLMMessage, LLMProvider
+
+DEFAULT_REPLAY_ROOT = Path(".titan") / "replays"
+TOKEN_RE = re.compile(r"\b[a-zA-Z0-9_]{3,}\b")
+
+
+class ReplayError(ValueError):
+    """Raised for invalid replay storage or target requests."""
+
+
+class CompletionRouter(Protocol):
+    """Router surface used by replay dispatch."""
+
+    async def complete(
+        self,
+        messages: list[LLMMessage],
+        *,
+        system: str | None = None,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+        provider: LLMProvider | None = None,
+        model: str | None = None,
+    ) -> Any:
+        """Complete a prompt for one provider/model target."""
+
+
+@dataclass(frozen=True)
+class ModelTarget:
+    """A provider/model replay target."""
+
+    provider: LLMProvider
+    model: str | None = None
+
+    @property
+    def label(self) -> str:
+        """Human-readable target label."""
+        return f"{self.provider.value}:{self.model}" if self.model else self.provider.value
+
+
+@dataclass(frozen=True)
+class ReplayRecord:
+    """Captured prompt and context for future replay."""
+
+    id: str
+    prompt: str
+    system: str | None
+    context: str | None
+    created_at: str
+
+
+@dataclass(frozen=True)
+class ReplayOutput:
+    """One model target output from a replay run."""
+
+    target: str
+    provider: str
+    model: str | None
+    content: str
+    latency_ms: float
+    usage: dict[str, int]
+    error: str | None = None
+
+
+@dataclass(frozen=True)
+class ReplayRun:
+    """Stored replay run results."""
+
+    id: str
+    record_id: str
+    created_at: str
+    outputs: list[ReplayOutput]
+
+
+def utc_now() -> str:
+    """Return a stable UTC timestamp for replay artifacts."""
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def make_id(prefix: str) -> str:
+    """Create a compact replay artifact id."""
+    stamp = datetime.now(UTC).strftime("%Y%m%d%H%M%S")
+    return f"{prefix}_{stamp}_{uuid4().hex[:8]}"
+
+
+def parse_model_targets(raw_targets: str) -> list[ModelTarget]:
+    """Parse comma-separated replay targets.
+
+    Target forms:
+    - `openai`
+    - `openai:gpt-4o-mini`
+    - `ollama/llama3.2`
+    """
+    targets: list[ModelTarget] = []
+    for raw_target in raw_targets.split(","):
+        target = raw_target.strip()
+        if not target:
+            continue
+        separator = ":" if ":" in target else "/" if "/" in target else ""
+        model: str | None
+        if separator:
+            provider_name, raw_model = target.split(separator, 1)
+            model = raw_model.strip() or None
+        else:
+            provider_name, model = target, None
+        try:
+            provider = LLMProvider(provider_name.strip().lower())
+        except ValueError as exc:
+            valid = ", ".join(provider.value for provider in LLMProvider)
+            message = f"Unknown provider '{provider_name}'. Valid providers: {valid}"
+            raise ReplayError(message) from exc
+        targets.append(ModelTarget(provider=provider, model=model))
+    return targets
+
+
+class ReplayStore:
+    """JSON-backed replay record and result storage."""
+
+    def __init__(self, root: Path = DEFAULT_REPLAY_ROOT) -> None:
+        self.root = root
+        self.records_dir = root / "records"
+        self.runs_dir = root / "runs"
+
+    def capture(
+        self,
+        *,
+        prompt: str,
+        system: str | None = None,
+        context: str | None = None,
+    ) -> ReplayRecord:
+        """Capture and persist a replay record."""
+        record = ReplayRecord(
+            id=make_id("rec"),
+            prompt=prompt,
+            system=system,
+            context=context,
+            created_at=utc_now(),
+        )
+        self.records_dir.mkdir(parents=True, exist_ok=True)
+        self._write_json(self.record_path(record.id), asdict(record))
+        return record
+
+    def record_path(self, record_id: str) -> Path:
+        """Return the path for a replay record."""
+        return self.records_dir / f"{record_id}.json"
+
+    def run_path(self, record_id: str, run_id: str) -> Path:
+        """Return the path for a replay run."""
+        return self.runs_dir / record_id / f"{run_id}.json"
+
+    def load_record(self, record_id: str) -> ReplayRecord:
+        """Load a captured replay record."""
+        path = self.record_path(record_id)
+        data = self._read_json(path)
+        return ReplayRecord(**data)
+
+    def save_run(self, run: ReplayRun) -> None:
+        """Persist replay run results."""
+        path = self.run_path(run.record_id, run.id)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        self._write_json(path, asdict(run))
+
+    def load_run(self, record_id: str, run_id: str) -> ReplayRun:
+        """Load a replay run."""
+        data = self._read_json(self.run_path(record_id, run_id))
+        outputs = [ReplayOutput(**output) for output in data["outputs"]]
+        return ReplayRun(
+            id=data["id"],
+            record_id=data["record_id"],
+            created_at=data["created_at"],
+            outputs=outputs,
+        )
+
+    def latest_run(self, record_id: str) -> ReplayRun:
+        """Load the most recent replay run for a record."""
+        run_dir = self.runs_dir / record_id
+        if not run_dir.is_dir():
+            raise ReplayError(f"No runs found for replay record {record_id}")
+        paths = sorted(run_dir.glob("run_*.json"), key=lambda path: path.stat().st_mtime)
+        if not paths:
+            raise ReplayError(f"No runs found for replay record {record_id}")
+        return self.load_run(record_id, paths[-1].stem)
+
+    @staticmethod
+    def _write_json(path: Path, payload: dict[str, Any]) -> None:
+        path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    @staticmethod
+    def _read_json(path: Path) -> dict[str, Any]:
+        if not path.is_file():
+            raise ReplayError(f"Replay artifact not found: {path}")
+        return cast(dict[str, Any], json.loads(path.read_text(encoding="utf-8")))
+
+
+def build_messages(record: ReplayRecord) -> list[LLMMessage]:
+    """Build replay messages from a captured record."""
+    content = record.prompt
+    if record.context:
+        content = f"{content}\n\nContext:\n{record.context}"
+    return [LLMMessage(role="user", content=content)]
+
+
+async def dispatch_replay(
+    record: ReplayRecord,
+    targets: list[ModelTarget],
+    router: CompletionRouter,
+    *,
+    max_tokens: int = 1024,
+    temperature: float | None = None,
+) -> ReplayRun:
+    """Replay a record across all requested targets."""
+    if len(targets) < 2:
+        raise ReplayError("Replay run requires at least two targets")
+
+    async def complete_target(target: ModelTarget) -> ReplayOutput:
+        start = time.perf_counter()
+        try:
+            response = await router.complete(
+                build_messages(record),
+                system=record.system,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                provider=target.provider,
+                model=target.model,
+            )
+            latency_ms = (time.perf_counter() - start) * 1000
+            content = str(getattr(response, "content", ""))
+            model = getattr(response, "model", target.model)
+            provider = str(getattr(response, "provider", target.provider.value))
+            usage = getattr(response, "usage", {})
+            return ReplayOutput(
+                target=target.label,
+                provider=provider,
+                model=str(model) if model is not None else None,
+                content=content,
+                latency_ms=round(latency_ms, 3),
+                usage=dict(usage) if isinstance(usage, dict) else {},
+            )
+        except Exception as exc:
+            latency_ms = (time.perf_counter() - start) * 1000
+            return ReplayOutput(
+                target=target.label,
+                provider=target.provider.value,
+                model=target.model,
+                content="",
+                latency_ms=round(latency_ms, 3),
+                usage={},
+                error=str(exc),
+            )
+
+    outputs = await asyncio.gather(*(complete_target(target) for target in targets))
+    return ReplayRun(
+        id=make_id("run"),
+        record_id=record.id,
+        created_at=utc_now(),
+        outputs=list(outputs),
+    )
+
+
+def tokenize(text: str) -> set[str]:
+    """Tokenize response text for rough agreement scoring."""
+    return {token.lower() for token in TOKEN_RE.findall(text)}
+
+
+def comparison_category(agreement_rate: float) -> str:
+    """Classify a pairwise comparison from token overlap."""
+    if agreement_rate >= 0.75:
+        return "agreement"
+    if agreement_rate >= 0.45:
+        return "phrasing_diff"
+    if agreement_rate >= 0.2:
+        return "semantic_diff"
+    return "factual_diff"
+
+
+def build_diff(run: ReplayRun) -> dict[str, Any]:
+    """Build a structured pairwise diff for a replay run."""
+    successful = [output for output in run.outputs if output.error is None]
+    comparisons: list[dict[str, Any]] = []
+    for left_index, left in enumerate(successful):
+        for right in successful[left_index + 1 :]:
+            left_tokens = tokenize(left.content)
+            right_tokens = tokenize(right.content)
+            union = left_tokens | right_tokens
+            shared = left_tokens & right_tokens
+            agreement_rate = len(shared) / len(union) if union else 1.0
+            right_length = max(len(right.content), 1)
+            comparisons.append(
+                {
+                    "left": left.target,
+                    "right": right.target,
+                    "agreement_rate": round(agreement_rate, 3),
+                    "length_ratio": round(len(left.content) / right_length, 3),
+                    "shared_terms": sorted(shared)[:25],
+                    "category": comparison_category(agreement_rate),
+                }
+            )
+
+    return {
+        "run_id": run.id,
+        "record_id": run.record_id,
+        "created_at": run.created_at,
+        "targets": [output.target for output in run.outputs],
+        "errors": [
+            {"target": output.target, "error": output.error}
+            for output in run.outputs
+            if output.error
+        ],
+        "comparisons": comparisons,
+    }
+
+
+def render_diff_markdown(run: ReplayRun, diff: dict[str, Any]) -> str:
+    """Render replay results and diff as Markdown."""
+    lines = [
+        f"# Replay Diff: {run.record_id}",
+        "",
+        f"- Run: `{run.id}`",
+        f"- Created: `{run.created_at}`",
+        "",
+        "## Outputs",
+    ]
+    for output in run.outputs:
+        status = "error" if output.error else "ok"
+        lines.extend(
+            [
+                "",
+                f"### {output.target}",
+                "",
+                f"- Status: `{status}`",
+                f"- Model: `{output.model or 'unknown'}`",
+                f"- Latency: `{output.latency_ms:.3f} ms`",
+            ]
+        )
+        if output.error:
+            lines.append(f"- Error: `{output.error}`")
+        else:
+            preview = output.content.strip() or "(empty response)"
+            lines.extend(["", "```text", preview, "```"])
+
+    lines.extend(["", "## Pairwise Comparisons", ""])
+    comparisons = diff["comparisons"]
+    if not comparisons:
+        lines.append("No successful output pairs were available for comparison.")
+    else:
+        lines.append("| Left | Right | Category | Agreement | Length Ratio |")
+        lines.append("| --- | --- | --- | ---: | ---: |")
+        for comparison in comparisons:
+            lines.append(
+                "| {left} | {right} | {category} | {agreement_rate:.3f} | "
+                "{length_ratio:.3f} |".format(**comparison)
+            )
+
+    if diff["errors"]:
+        lines.extend(["", "## Errors"])
+        for error in diff["errors"]:
+            lines.append(f"- `{error['target']}`: {error['error']}")
+
+    return "\n".join(lines) + "\n"


### PR DESCRIPTION
## Summary

Implements the cross-model replay/diff workflow described in `docs/cross-model-replay.md`.

## Changes

- Add `titan.replay` for JSON-backed replay capture, multi-target dispatch, stored run results, and pairwise diff generation.
- Add `titan replay capture`, `titan replay run`, and `titan replay diff` CLI commands.
- Add deterministic tests using fake routers so replay behavior is covered without external model calls.
- Update the replay design doc with implemented command examples and storage behavior.

## Related Issues

Fixes #26

## Testing

- [x] `uv run --python 3.11 --with '.[dev,dashboard,auth,ratelimit]' ruff check .`
- [x] `uv run --python 3.11 --with '.[dev,dashboard,auth,ratelimit]' mypy .`
- [x] `uv run --python 3.11 --with '.[dev,dashboard,auth,ratelimit]' pytest tests/test_replay.py tests/test_adapters.py`
- [x] `UV_NO_CACHE=1 uv run --python 3.11 --with '.[dev,dashboard,auth,ratelimit]' titan replay --help`

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Documentation updated
- [x] No secrets or credentials included