### PR TITLE
docs: preserve audit-lane closeout summary (2026-06-07)

### DIFF
--- a/.claude/plans/2026-06-07-closeout-summary-audit-lane.md
+++ b/.claude/plans/2026-06-07-closeout-summary-audit-lane.md
@@ -1,0 +1,58 @@
+# Closeout Summary: agentic-titan Session 2026-06-07
+
+**Lane:** agentic-titan (ORGAN-IV) | **Date:** 2026-06-07 | **Verdict:** SAFE TO CLOSE
+
+## What Changed This Lane
+
+| Artifact | Status | Evidence |
+|----------|--------|----------|
+| `.claude/plans/2026-06-07-cross-agent-handoff.md` | Created (untracked) | Handoff document for next agent |
+| Any code files | **None** | `git diff HEAD --stat` empty |
+| Any commits | **None** | `git log` unchanged |
+| seed.yaml | Unchanged | last_validated still 2026-02-11 |
+
+**This was a read-only audit session.** No production code was modified. The only write was the handoff artifact.
+
+## Closeout Surfaces
+
+| Surface | Status | Notes |
+|---------|--------|-------|
+| Plans | ✅ | Handoff doc exists at `.claude/plans/2026-06-07-cross-agent-handoff.md` |
+| Artifacts | ✅ | No artifacts to close — read-only session |
+| Git state | ✅ | Clean, on main, up to date with origin |
+| Local:remote parity | ✅ | 1:1 — nothing local to push |
+| IRF obligations | ⚠️ | No IRF update needed — no work completed, only audit findings |
+| Registry/seed | ⚠️ | seed.yaml last_validated 2026-02-11 (stale, not blocking) |
+
+## Findings
+
+### Completed (Verification Only)
+- IRF read: 923 DONE items system-wide, 9 open GitHub issues
+- CI status: All green (Python CI, CodeQL, Secret Scan, Release Drafter)
+- Git state: Clean, no uncommitted work
+
+### Discovered Vacuums (Not Fixed)
+1. **Logos Documentation Layer** — `CLAUDE.md:303` and `GEMINI.md:206` both flag Status: MISSING, Symmetry: 0.0 (VACUUM). Files exist in `docs/logos/` but layer status is wrong. **Owner: governance.**
+2. **Issue #87** — Generated context drift. Preservation branch `codex/context-refresh-preserve-2026-06-07` exists with 3 files (35 insertions, 233 deletions). **No decision made.** Owner: human.
+3. **seed.yaml stale** — `last_validated: "2026-02-11"`, `generated: "2026-02-12"`. 4+ months stale. **Owner: agent (low priority).**
+
+### IRF Items Noted (No Action Taken)
+- IRF-SYS-156 (P0): Notification backlog — system-wide, not agentic-titan-specific
+- IRF-SYS-087 (P0): UMFAS birth — system-wide
+- IRF-ATN-006 (P2): `_extract_naming_patterns` stub — existing, not new
+- IRF-ATN-009 (P3): Unused config fields — existing, not new
+
+## Remaining Gaps
+
+| Gap | Severity | Minimum Next Action |
+|-----|----------|---------------------|
+| Issue #87 unresolved | **High** | Human decides: merge / regenerate / restore |
+| Logos vacuum unfixed | **Medium** | Populate `docs/logos/` files OR remove VACUUM flag |
+| seed.yaml stale | **Low** | Run `organvm refresh` or manual update |
+| Handoff untracked | **Low** | `git add .claude/plans/2026-06-07-cross-agent-handoff.md` if persistence desired |
+
+## Safe-to-Close Verdict
+
+**SAFE TO CLOSE.** This was a read-only audit session. No production code was modified. No commits are pending. The only artifact (handoff doc) is untracked and optional. All findings are documented in the handoff artifact for the next agent.
+
+No push authority needed — nothing to push.


### PR DESCRIPTION
Recovers the read-only audit lane's closeout summary, which sat untracked in the `wip/closeout-2026-06-07` worktree under a filename colliding with the remediation lane's closeout. Distinct content: Issue #87 finding, seed.yaml staleness, pre-remediation Logos state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)